### PR TITLE
[FEAT] 진행중인 스터디 관련 API 구현

### DIFF
--- a/src/main/java/com/example/SpotApplication.java
+++ b/src/main/java/com/example/SpotApplication.java
@@ -2,8 +2,10 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SpotApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4001", "스터디를 찾을 수 없습니다."),
     _STUDY_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4002", "스터디장을 찾을 수 없습니다."),
     _STUDY_ALREADY_APPLIED(HttpStatus.FORBIDDEN, "STUDY4003", "이미 신청된 스터디입니다."),
+    _STUDY_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "STUDY4007", "스터디 모집기한이 아닙니다."),
 
     //스터디 게시물 관련 에러
     _STUDY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "스터디 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -23,7 +23,10 @@ public enum ErrorStatus implements BaseErrorCode {
     //스터디 관련 에러
     _STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4001", "스터디를 찾을 수 없습니다."),
     _STUDY_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4002", "스터디장을 찾을 수 없습니다."),
-    _STUDY_ALREADY_APPLIED(HttpStatus.FORBIDDEN, "STUDY4003", "이미 신청된 스터디입니다."),
+    _STUDY_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "STUDY4003", "이미 신청된 스터디입니다."),
+    _STUDY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4004", "스터디 회원을 찾을 수 없습니다."),
+    _STUDY_NOT_APPROVED(HttpStatus.FORBIDDEN, "STUDY4005", "승인되지 않은 스터디입니다."),
+    _STUDY_OWNER_CANNOT_WITHDRAW(HttpStatus.FORBIDDEN, "STUDY4006", "스터디장은 스터디를 탈퇴할 수 없습니다."),
     _STUDY_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "STUDY4007", "스터디 모집기한이 아닙니다."),
 
     //스터디 게시물 관련 에러

--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -20,10 +20,22 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBER_NAME_INVALID(HttpStatus.BAD_REQUEST, "MEMBER4002", "회원 이름이 유효하지 않습니다."),
     _MEMBER_BIRTH_INVALID(HttpStatus.BAD_REQUEST, "MEMBER4005", "생년월일이 유효하지 않습니다."),
 
+    //스터디 관련 에러
+    _STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4001", "스터디를 찾을 수 없습니다."),
+    _STUDY_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4002", "스터디장을 찾을 수 없습니다."),
+    _STUDY_ALREADY_APPLIED(HttpStatus.FORBIDDEN, "STUDY4003", "이미 신청된 스터디입니다."),
+
     //스터디 게시물 관련 에러
     _STUDY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "스터디 게시글을 찾을 수 없습니다."),
     _STUDY_POST_TITLE_INVALID(HttpStatus.BAD_REQUEST, "POST4002", "스터디 게시글 제목이 유효하지 않습니다."),
     _STUDY_POST_CONTENT_INVALID(HttpStatus.BAD_REQUEST, "POST4003", "스터디 게시글 내용이 유효하지 않습니다."),
+
+    //지역 관련 에러
+    _REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4001", "지역을 찾을 수 없습니다."),
+
+    // 스터디 테마 에러
+    _THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "THEME4001", "스터디 테마를 찾을 수 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
@@ -33,7 +33,15 @@ public enum SuccessStatus implements BaseCode {
     _STUDY_POST_COMMENT_CREATED(HttpStatus.CREATED, "STUDYPOST3008", "스터디 게시글 댓글 작성 완료"),
     _STUDY_POST_COMMENT_UPDATED(HttpStatus.OK, "STUDYPOST3009", "스터디 게시글 댓글 수정 완료"),
     _STUDY_POST_COMMENT_DELETED(HttpStatus.OK, "STUDYPOST3010", "스터디 게시글 댓글 삭제 완료"),
-    _STUDY_FOUND(HttpStatus.OK, "STUDYPOST3011", "스터디 조회 완료");
+
+    //스터디 관련
+    _STUDY_CREATED(HttpStatus.CREATED, "STUDY4001", "스터디 생성 완료"),
+    _STUDY_UPDATED(HttpStatus.OK, "STUDY4002", "스터디 수정 완료"),
+    _STUDY_FOUND(HttpStatus.OK, "STUDY4003", "스터디 조회 완료"),
+    _STUDY_MEMBER_CREATED(HttpStatus.CREATED, "STUDY4004", "스터디 참여 완료"),
+
+
+    ;
   
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
@@ -39,6 +39,8 @@ public enum SuccessStatus implements BaseCode {
     _STUDY_UPDATED(HttpStatus.OK, "STUDY4002", "스터디 수정 완료"),
     _STUDY_FOUND(HttpStatus.OK, "STUDY4003", "스터디 조회 완료"),
     _STUDY_MEMBER_CREATED(HttpStatus.CREATED, "STUDY4004", "스터디 참여 완료"),
+    _STUDY_MEMBER_DELETED(HttpStatus.OK, "STUDY4005", "스터디 탈퇴 완료"),
+    _STUDY_TERMINATED(HttpStatus.OK, "STUDY4006", "스터디 종료 완료"),
 
 
     ;

--- a/src/main/java/com/example/spot/domain/Member.java
+++ b/src/main/java/com/example/spot/domain/Member.java
@@ -3,6 +3,7 @@ package com.example.spot.domain;
 import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.enums.Carrier;
 import com.example.spot.domain.mapping.*;
+import com.example.spot.domain.study.Study;
 import com.example.spot.domain.study.StudyPost;
 import com.example.spot.domain.study.StudyPostComment;
 import com.example.spot.domain.study.Vote;
@@ -57,6 +58,7 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "BIT DEFAULT 0")
     private Boolean isAdmin;
+
 
     //== 스터디 희망사유 ==//
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
@@ -137,5 +139,13 @@ public class Member extends BaseEntity {
     //== 회원이 투표한 항목 목록 ==//
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberVote> memberVoteList;
+
+
+/* ----------------------------- 연관관계 메소드 ------------------------------------- */
+
+    public void addMemberStudy(MemberStudy memberStudy) {
+        memberStudyList.add(memberStudy);
+        memberStudy.setMember(this);
+    }
 
 }

--- a/src/main/java/com/example/spot/domain/Region.java
+++ b/src/main/java/com/example/spot/domain/Region.java
@@ -14,9 +14,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Region {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,6 +33,18 @@ public class Region {
     @OneToMany(mappedBy = "region")
     private List<PreferredRegion> prefferedRegionList = new ArrayList<>();
 
+
+/* ----------------------------- 생성자 ------------------------------------- */
+
+    protected Region() {}
+
+    @Builder
+    public Region(String code, String province, String district, String neighborhood) {
+        this.code = code;
+        this.province = province;
+        this.district = district;
+        this.neighborhood = neighborhood;
+    }
 
 /* ----------------------------- 연관관계 메소드 ------------------------------------- */
 

--- a/src/main/java/com/example/spot/domain/Region.java
+++ b/src/main/java/com/example/spot/domain/Region.java
@@ -36,4 +36,16 @@ public class Region {
     @OneToMany(mappedBy = "region")
     private List<PreferredRegion> prefferedRegionList = new ArrayList<>();
 
+
+/* ----------------------------- 연관관계 메소드 ------------------------------------- */
+
+    public void addRegionStudy(RegionStudy regionStudy) {
+        regionStudyList.add(regionStudy);
+        regionStudy.setRegion(this);
+    }
+
+    public void addPreferredRegion(PreferredRegion preferredRegion) {
+        prefferedRegionList.add(preferredRegion);
+        preferredRegion.setRegion(this);
+    }
 }

--- a/src/main/java/com/example/spot/domain/Theme.java
+++ b/src/main/java/com/example/spot/domain/Theme.java
@@ -40,4 +40,16 @@ public class Theme {
     @OneToMany(mappedBy = "theme", cascade = CascadeType.ALL)
     private List<StudyTheme> studyThemeList;
 
+
+/* ----------------------------- 연관관계 메소드 ------------------------------------- */
+
+    public void addMemberTheme(MemberTheme memberTheme) {
+        memberThemeList.add(memberTheme);
+        memberTheme.setTheme(this);
+    }
+
+    public void addStudyTheme(StudyTheme studyTheme) {
+        studyThemeList.add(studyTheme);
+        studyTheme.setTheme(this);
+    }
 }

--- a/src/main/java/com/example/spot/domain/mapping/MemberStudy.java
+++ b/src/main/java/com/example/spot/domain/mapping/MemberStudy.java
@@ -4,7 +4,9 @@ import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.ApplicationStatus;
 import com.example.spot.domain.study.Study;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -26,12 +28,30 @@ public class MemberStudy {
     private String introduction;
 
     //== 회원 ==//
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     //== 스터디 ==//
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id", nullable = false)
     private Study study;
+
+/* ----------------------------- 생성자 ------------------------------------- */
+
+    protected MemberStudy() {}
+
+    @Builder
+    public MemberStudy(Boolean isOwned, String introduction, Member member, Study study, ApplicationStatus status) {
+
+        this.isOwned = isOwned;
+        this.introduction = introduction;
+        this.member = member;
+        this.study = study;
+        this.status = status;
+    }
+
+
 }

--- a/src/main/java/com/example/spot/domain/mapping/MemberTheme.java
+++ b/src/main/java/com/example/spot/domain/mapping/MemberTheme.java
@@ -4,6 +4,7 @@ import com.example.spot.domain.Member;
 import com.example.spot.domain.Theme;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -15,11 +16,13 @@ public class MemberTheme {
     private Long id;
 
     //== 회원 ==//
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     //== 회원 테마 ==//
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theme_id", nullable = false)
     private Theme theme;

--- a/src/main/java/com/example/spot/domain/mapping/PreferredRegion.java
+++ b/src/main/java/com/example/spot/domain/mapping/PreferredRegion.java
@@ -4,6 +4,7 @@ import com.example.spot.domain.Region;
 import com.example.spot.domain.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -14,10 +15,12 @@ public class PreferredRegion {
     @Column(nullable = false, unique = true)
     private Long id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id", nullable = false)
     private Region region;

--- a/src/main/java/com/example/spot/domain/mapping/RegionStudy.java
+++ b/src/main/java/com/example/spot/domain/mapping/RegionStudy.java
@@ -4,24 +4,33 @@ import com.example.spot.domain.Region;
 import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.study.Study;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RegionStudy extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id")
     private Region region;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id")
     private Study study;
+
+/* ----------------------------- 생성자 ------------------------------------- */
+
+    protected RegionStudy() {}
+
+    @Builder
+    public RegionStudy(Region region, Study study) {
+        this.region = region;
+        this.study = study;
+    }
 }

--- a/src/main/java/com/example/spot/domain/mapping/StudyTheme.java
+++ b/src/main/java/com/example/spot/domain/mapping/StudyTheme.java
@@ -3,7 +3,9 @@ package com.example.spot.domain.mapping;
 import com.example.spot.domain.Theme;
 import com.example.spot.domain.study.Study;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -15,12 +17,24 @@ public class StudyTheme {
     private Long id;
 
     //== 테마 ==//
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theme_id", nullable = false)
     private Theme theme;
 
     //== 스터디 ==//
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id", nullable = false)
     private Study study;
+
+/* ----------------------------- 생성자 ------------------------------------- */
+
+    protected StudyTheme() {}
+
+    @Builder
+    public StudyTheme(Theme theme, Study study) {
+        this.theme = theme;
+        this.study = study;
+    }
 }

--- a/src/main/java/com/example/spot/domain/study/Study.java
+++ b/src/main/java/com/example/spot/domain/study/Study.java
@@ -4,6 +4,9 @@ import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.enums.Gender;
 import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.enums.StudyState;
+import com.example.spot.domain.mapping.MemberStudy;
+import com.example.spot.domain.mapping.RegionStudy;
+import com.example.spot.domain.mapping.StudyTheme;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,26 +16,22 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+
+import java.util.ArrayList;
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
-@Builder
 @DynamicUpdate
 @DynamicInsert
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Study extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -52,10 +51,10 @@ public class Study extends BaseEntity {
     private StudyState studyState;
 
     @Column(nullable = false)
-    private boolean isOnline;
+    private Boolean isOnline;
 
     @Column(nullable = false)
-    private int heartCount;
+    private Integer heartCount;
 
     @Column(nullable = false)
     private String goal;
@@ -73,6 +72,9 @@ public class Study extends BaseEntity {
     @Column(nullable = false)
     private Long hitNum;
 
+    @Column(nullable = false)
+    private Long maxPeople;
+
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
     private List<Schedule> schedules;
 
@@ -82,4 +84,60 @@ public class Study extends BaseEntity {
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
     private List<Vote> votes;
 
+    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+    private List<StudyTheme> studyThemes;
+
+    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+    private List<MemberStudy> memberStudies;
+
+    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+    private List<RegionStudy> regionStudies;
+
+/* ----------------------------- 생성자 ------------------------------------- */
+
+    protected Study() {}
+
+    @Builder
+    public Study(Gender gender, Integer minAge, Integer maxAge, Integer fee,
+                    Boolean isOnline, String goal, String introduction,
+                    String title, Long maxPeople) {
+        this.gender = gender;
+        this.minAge = minAge;
+        this.maxAge = maxAge;
+        this.fee = fee;
+        this.studyState = StudyState.BEFORE;
+        this.isOnline = isOnline;
+        this.heartCount = 0;
+        this.goal = goal;
+        this.introduction = introduction;
+        this.title = title;
+        this.status = Status.ON;
+        this.hitNum = 0L;
+        this.maxPeople = maxPeople;
+        this.schedules = new ArrayList<>();
+        this.posts = new ArrayList<>();
+        this.votes = new ArrayList<>();
+        this.studyThemes = new ArrayList<>();
+        this.memberStudies = new ArrayList<>();
+        this.regionStudies = new ArrayList<>();
+
+    }
+
+
+/* ----------------------------- 연관관계 메소드 ------------------------------------- */
+
+    public void addMemberStudy(MemberStudy memberStudy) {
+        memberStudies.add(memberStudy);
+        memberStudy.setStudy(this);
+    }
+
+    public void addRegionStudy(RegionStudy regionStudy) {
+        regionStudies.add(regionStudy);
+        regionStudy.setStudy(this);
+    }
+
+    public void addStudyTheme(StudyTheme studyTheme) {
+        studyThemes.add(studyTheme);
+        studyTheme.setStudy(this);
+    }
 }

--- a/src/main/java/com/example/spot/domain/study/Study.java
+++ b/src/main/java/com/example/spot/domain/study/Study.java
@@ -65,6 +65,7 @@ public class Study extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
+    @Setter
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Status status;
@@ -140,4 +141,5 @@ public class Study extends BaseEntity {
         studyThemes.add(studyTheme);
         studyTheme.setStudy(this);
     }
+
 }

--- a/src/main/java/com/example/spot/repository/MemberRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 @Repository
 public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> {
 
-    List<MemberStudy> findByMember_Id(Long memberId);
+    List<MemberStudy> findByMemberId(Long memberId);
     Optional<MemberStudy> findByMemberIdAndStudyId(Long memberId, Long studyId);
 }

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> {
 
     List<MemberStudy> findByMember_Id(Long memberId);
+    Optional<MemberStudy> findByMemberIdAndStudyId(Long memberId, Long studyId);
 }

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -1,0 +1,13 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.mapping.MemberStudy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> {
+
+    List<MemberStudy> findByMember_Id(Long memberId);
+}

--- a/src/main/java/com/example/spot/repository/RegionRepository.java
+++ b/src/main/java/com/example/spot/repository/RegionRepository.java
@@ -2,7 +2,15 @@ package com.example.spot.repository;
 
 import com.example.spot.domain.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
+@Repository
 public interface RegionRepository extends JpaRepository<Region, Long> {
 
+    List<Region> findAllByProvince(String province);
+    List<Region> findAllByDistrict(String district);
+    Optional<Region> findByProvinceAndDistrictAndNeighborhood(String province, String district, String neighborhood);
 }

--- a/src/main/java/com/example/spot/repository/RegionStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/RegionStudyRepository.java
@@ -1,0 +1,9 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.mapping.RegionStudy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RegionStudyRepository extends JpaRepository<RegionStudy, Long> {
+}

--- a/src/main/java/com/example/spot/repository/StudyRepository.java
+++ b/src/main/java/com/example/spot/repository/StudyRepository.java
@@ -1,0 +1,9 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.study.Study;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyRepository extends JpaRepository<Study,Long> {
+}

--- a/src/main/java/com/example/spot/repository/StudyThemeRepository.java
+++ b/src/main/java/com/example/spot/repository/StudyThemeRepository.java
@@ -1,0 +1,9 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.mapping.StudyTheme;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyThemeRepository extends JpaRepository<StudyTheme, Long> {
+}

--- a/src/main/java/com/example/spot/repository/ThemeRepository.java
+++ b/src/main/java/com/example/spot/repository/ThemeRepository.java
@@ -1,0 +1,14 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.Theme;
+import com.example.spot.domain.enums.ThemeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ThemeRepository extends JpaRepository<Theme, Long> {
+
+    Optional<Theme> findByStudyTheme(ThemeType themeType);
+}

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandService.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandService.java
@@ -1,0 +1,11 @@
+package com.example.spot.service.memberstudy;
+
+import com.example.spot.web.dto.memberstudy.response.StudyTerminationResponseDTO;
+import com.example.spot.web.dto.memberstudy.response.StudyWithdrawalResponseDTO;
+
+public interface MemberStudyCommandService {
+
+    StudyWithdrawalResponseDTO.WithdrawalDTO withdrawFromStudy(Long memberId, Long studyId);
+
+    StudyTerminationResponseDTO.TerminationDTO terminateStudy(Long studyId);
+}

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
@@ -1,0 +1,70 @@
+package com.example.spot.service.memberstudy;
+
+import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.handler.MemberHandler;
+import com.example.spot.api.exception.handler.StudyHandler;
+import com.example.spot.domain.Member;
+import com.example.spot.domain.enums.ApplicationStatus;
+import com.example.spot.domain.enums.Status;
+import com.example.spot.domain.mapping.MemberStudy;
+import com.example.spot.domain.study.Study;
+import com.example.spot.repository.MemberRepository;
+import com.example.spot.repository.MemberStudyRepository;
+import com.example.spot.repository.StudyRepository;
+import com.example.spot.web.dto.memberstudy.response.StudyTerminationResponseDTO;
+import com.example.spot.web.dto.memberstudy.response.StudyWithdrawalResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class MemberStudyCommandServiceImpl implements MemberStudyCommandService {
+
+    private final MemberRepository memberRepository;
+    private final StudyRepository studyRepository;
+    private final MemberStudyRepository memberStudyRepository;
+
+/* ----------------------------- 진행중인 스터디 관련 API ------------------------------------- */
+
+    // [진행중인 스터디] 스터디 탈퇴하기
+    @Transactional
+    public StudyWithdrawalResponseDTO.WithdrawalDTO withdrawFromStudy(Long memberId, Long studyId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_NOT_FOUND));
+
+        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyId(memberId, studyId)
+                .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_MEMBER_NOT_FOUND));
+
+        // 참여가 승인되지 않은 스터디는 탈퇴할 수 없음
+        if (memberStudy.getStatus().equals(ApplicationStatus.APPLIED)) {
+            throw new StudyHandler(ErrorStatus._STUDY_NOT_APPROVED);
+        }
+        // 스터디장은 스터디를 탈퇴할 수 없음
+        if (memberStudy.getIsOwned()) {
+            throw new StudyHandler(ErrorStatus._STUDY_OWNER_CANNOT_WITHDRAW);
+        }
+
+        memberStudyRepository.delete(memberStudy);
+
+        return StudyWithdrawalResponseDTO.WithdrawalDTO.toDTO(member, study);
+    }
+
+    // [진행중인 스터디] 스터디 끝내기
+    @Transactional
+    public StudyTerminationResponseDTO.TerminationDTO terminateStudy(Long studyId) {
+
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_NOT_FOUND));
+
+        study.setStatus(Status.OFF);
+        studyRepository.save(study);
+
+        return StudyTerminationResponseDTO.TerminationDTO.toDTO(study);
+    }
+}

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryService.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryService.java
@@ -1,0 +1,4 @@
+package com.example.spot.service.memberstudy;
+
+public interface MemberStudyQueryService {
+}

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryServiceImpl.java
@@ -1,0 +1,7 @@
+package com.example.spot.service.memberstudy;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberStudyQueryServiceImpl implements MemberStudyQueryService {
+}

--- a/src/main/java/com/example/spot/service/post/PostService.java
+++ b/src/main/java/com/example/spot/service/post/PostService.java
@@ -1,4 +1,4 @@
-package com.example.spot.web.service;
+package com.example.spot.service.post;
 
 import com.example.spot.web.dto.post.*;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/example/spot/service/study/StudyCommandService.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandService.java
@@ -1,0 +1,13 @@
+package com.example.spot.service.study;
+
+import com.example.spot.web.dto.study.request.StudyJoinRequestDTO;
+import com.example.spot.web.dto.study.request.StudyRegisterRequestDTO;
+import com.example.spot.web.dto.study.response.StudyJoinResponseDTO;
+import com.example.spot.web.dto.study.response.StudyRegisterResponseDTO;
+
+public interface StudyCommandService {
+
+    StudyJoinResponseDTO.JoinDTO applyToStudy(Long memberId, Long studyId, StudyJoinRequestDTO.StudyJoinDTO studyJoinRequestDTO);
+
+    StudyRegisterResponseDTO.RegisterDTO registerStudy(Long memberId, StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO);
+}

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.spot.domain.Member;
 import com.example.spot.domain.Region;
 import com.example.spot.domain.Theme;
 import com.example.spot.domain.enums.ApplicationStatus;
+import com.example.spot.domain.enums.StudyState;
 import com.example.spot.domain.mapping.MemberStudy;
 import com.example.spot.domain.mapping.RegionStudy;
 import com.example.spot.domain.mapping.StudyTheme;
@@ -46,6 +47,11 @@ public class StudyCommandServiceImpl implements StudyCommandService {
 
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_NOT_FOUND));
+
+        // 모집중이지 않은 스터디에 신청할 수 없음
+        if (study.getStudyState() != StudyState.RECRUITING) {
+            throw new StudyHandler(ErrorStatus._STUDY_NOT_RECRUITING);
+        }
 
         // 이미 신청한 스터디에 다시 신청할 수 없음
         List<MemberStudy> memberStudyList = memberStudyRepository.findByMember_Id(memberId).stream()

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -54,7 +54,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
         }
 
         // 이미 신청한 스터디에 다시 신청할 수 없음
-        List<MemberStudy> memberStudyList = memberStudyRepository.findByMember_Id(memberId).stream()
+        List<MemberStudy> memberStudyList = memberStudyRepository.findByMemberId(memberId).stream()
                 .filter(memberStudy -> study.equals(memberStudy.getStudy()))
                 .toList();
 

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -1,0 +1,164 @@
+package com.example.spot.service.study;
+
+import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.handler.MemberHandler;
+import com.example.spot.api.exception.handler.StudyHandler;
+import com.example.spot.domain.Member;
+import com.example.spot.domain.Region;
+import com.example.spot.domain.Theme;
+import com.example.spot.domain.enums.ApplicationStatus;
+import com.example.spot.domain.mapping.MemberStudy;
+import com.example.spot.domain.mapping.RegionStudy;
+import com.example.spot.domain.mapping.StudyTheme;
+import com.example.spot.domain.study.Study;
+import com.example.spot.repository.*;
+import com.example.spot.web.dto.study.request.StudyJoinRequestDTO;
+import com.example.spot.web.dto.study.request.StudyRegisterRequestDTO;
+import com.example.spot.web.dto.study.response.StudyJoinResponseDTO;
+import com.example.spot.web.dto.study.response.StudyRegisterResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudyCommandServiceImpl implements StudyCommandService {
+
+    private final MemberRepository memberRepository;
+    private final StudyRepository studyRepository;
+    private final RegionRepository regionRepository;
+    private final ThemeRepository themeRepository;
+
+    private final MemberStudyRepository memberStudyRepository;
+    private final RegionStudyRepository regionStudyRepository;
+    private final StudyThemeRepository studyThemeRepository;
+
+    /* ----------------------------- 스터디 생성/참여 관련 API ------------------------------------- */
+
+    // [스터디 생성/참여] 참여 신청하기
+    @Transactional
+    public StudyJoinResponseDTO.JoinDTO applyToStudy(Long memberId, Long studyId,
+                                                     StudyJoinRequestDTO.StudyJoinDTO studyJoinRequestDTO) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_NOT_FOUND));
+
+        // 이미 신청한 스터디에 다시 신청할 수 없음
+        List<MemberStudy> memberStudyList = memberStudyRepository.findByMember_Id(memberId).stream()
+                .filter(memberStudy -> study.equals(memberStudy.getStudy()))
+                .toList();
+
+        if (!memberStudyList.isEmpty()) {
+            throw new StudyHandler(ErrorStatus._STUDY_ALREADY_APPLIED);
+        }
+
+        MemberStudy memberStudy = MemberStudy.builder()
+                .isOwned(false)
+                .introduction(studyJoinRequestDTO.getIntroduction())
+                .member(member)
+                .study(study)
+                .status(ApplicationStatus.APPLIED)
+                .build();
+
+        member.addMemberStudy(memberStudy);
+        study.addMemberStudy(memberStudy);
+        memberStudyRepository.save(memberStudy);
+
+        return StudyJoinResponseDTO.JoinDTO.toDTO(member, study);
+    }
+
+    // [스터디 생성/참여] 참여 신청하기
+    @Transactional
+    public StudyRegisterResponseDTO.RegisterDTO registerStudy(Long memberId, StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        Study study = Study.builder()
+                .gender(studyRegisterRequestDTO.getGender())
+                .minAge(studyRegisterRequestDTO.getMinAge())
+                .maxAge(studyRegisterRequestDTO.getMaxAge())
+                .fee(studyRegisterRequestDTO.getFee())
+                .isOnline(studyRegisterRequestDTO.getIsOnline())
+                .goal(studyRegisterRequestDTO.getGoal())
+                .introduction(studyRegisterRequestDTO.getIntroduction())
+                .title(studyRegisterRequestDTO.getTitle())
+                .maxPeople(studyRegisterRequestDTO.getMaxPeople())
+                .build();
+
+        study = studyRepository.save(study);
+
+        createMemberStudy(member, study);
+        createRegionStudy(study, studyRegisterRequestDTO);
+        createStudyTheme(study, studyRegisterRequestDTO);
+
+        studyRepository.save(study);
+
+        return StudyRegisterResponseDTO.RegisterDTO.toDTO(study);
+    }
+
+    private void createMemberStudy(Member member, Study study) {
+
+        MemberStudy memberStudy = MemberStudy.builder()
+                .isOwned(true)
+                .introduction(study.getIntroduction())
+                .member(member)
+                .study(study)
+                .status(ApplicationStatus.APPROVED)
+                .build();
+
+        member.addMemberStudy(memberStudy);
+        study.addMemberStudy(memberStudy);
+        memberStudyRepository.save(memberStudy);
+
+        study.addMemberStudy(memberStudy);
+
+    }
+
+    private void createRegionStudy(Study study, StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO) {
+
+        studyRegisterRequestDTO.getRegions()
+                .forEach(stringRegion -> {
+
+                    Region region = regionRepository
+                            .findByProvinceAndDistrictAndNeighborhood(stringRegion.getProvince(), stringRegion.getDistrict(), stringRegion.getNeighborhood())
+                            .orElseThrow(() -> new StudyHandler(ErrorStatus._REGION_NOT_FOUND));
+
+                    RegionStudy regionStudy = RegionStudy.builder()
+                            .region(region)
+                            .study(study)
+                            .build();
+
+                    region.addRegionStudy(regionStudy);
+                    study.addRegionStudy(regionStudy);
+                    regionStudyRepository.save(regionStudy);
+
+                    study.addRegionStudy(regionStudy);
+                });
+    }
+
+    private void createStudyTheme(Study study, StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO) {
+
+        studyRegisterRequestDTO.getThemes()
+                .forEach(stringTheme -> {
+
+                    Theme theme = themeRepository.findByStudyTheme(stringTheme)
+                            .orElseThrow(() -> new StudyHandler(ErrorStatus._THEME_NOT_FOUND));
+
+                    StudyTheme studyTheme = StudyTheme.builder()
+                            .theme(theme)
+                            .study(study)
+                            .build();
+
+                    study.addStudyTheme(studyTheme);
+                    theme.addStudyTheme(studyTheme);
+                    studyThemeRepository.save(studyTheme);
+
+                    study.addStudyTheme(studyTheme);
+                });
+    }
+}

--- a/src/main/java/com/example/spot/service/study/StudyQueryService.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryService.java
@@ -1,0 +1,8 @@
+package com.example.spot.service.study;
+
+import com.example.spot.web.dto.study.response.StudyInfoResponseDTO;
+
+public interface StudyQueryService {
+
+    public StudyInfoResponseDTO.StudyInfoDTO getStudyInfo(Long studyId);
+}

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.spot.service.study;
+
+import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.handler.StudyHandler;
+import com.example.spot.domain.Member;
+import com.example.spot.domain.mapping.MemberStudy;
+import com.example.spot.domain.study.Study;
+import com.example.spot.repository.MemberRepository;
+import com.example.spot.repository.MemberStudyRepository;
+import com.example.spot.repository.StudyRepository;
+import com.example.spot.web.dto.study.response.StudyInfoResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudyQueryServiceImpl implements StudyQueryService {
+
+    private final MemberRepository memberRepository;
+    private final MemberStudyRepository memberStudyRepository;
+    private final StudyRepository studyRepository;
+
+/* ----------------------------- 스터디 생성/참여 관련 API ------------------------------------- */
+
+    public StudyInfoResponseDTO.StudyInfoDTO getStudyInfo(Long studyId) {
+
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_NOT_FOUND));
+
+        List<MemberStudy> memberStudyList = study.getMemberStudies().stream()
+                .filter(MemberStudy::getIsOwned)
+                .toList();
+
+        if (memberStudyList.isEmpty()) {
+            throw new StudyHandler(ErrorStatus._STUDY_OWNER_NOT_FOUND);
+        }
+
+        Member owner = memberStudyList.get(0).getMember();
+        return StudyInfoResponseDTO.StudyInfoDTO.toDTO(study, owner);
+    }
+}

--- a/src/main/java/com/example/spot/web/controller/MemberStudyController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberStudyController.java
@@ -1,13 +1,24 @@
 package com.example.spot.web.controller;
 
+import com.example.spot.api.ApiResponse;
+import com.example.spot.api.code.status.SuccessStatus;
+import com.example.spot.service.memberstudy.MemberStudyCommandService;
+import com.example.spot.service.memberstudy.MemberStudyQueryService;
+import com.example.spot.web.dto.memberstudy.response.StudyTerminationResponseDTO;
+import com.example.spot.web.dto.memberstudy.response.StudyWithdrawalResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "MemberStudy", description = "MemberStudy API(내 스터디 관련 API)")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/spot")
 public class MemberStudyController {
+
+    private final MemberStudyQueryService memberStudyQueryService;
+    private final MemberStudyCommandService memberStudyCommandService;
 
 /* ----------------------------- 진행중인 스터디 관련 API ------------------------------------- */
 
@@ -32,7 +43,9 @@ public class MemberStudyController {
         로그인한 회원이 참여하는 특정 스터디에 대해 member_study 튜플을 삭제합니다.
         """)
     @DeleteMapping("/members/{memberId}/studies/{studyId}/withdrawal")
-    public void withdrawFromStudy(@PathVariable Long memberId, @PathVariable Long studyId) {
+    public ApiResponse<StudyWithdrawalResponseDTO.WithdrawalDTO> withdrawFromStudy(@PathVariable Long memberId, @PathVariable Long studyId) {
+        StudyWithdrawalResponseDTO.WithdrawalDTO withdrawalDTO = memberStudyCommandService.withdrawFromStudy(memberId, studyId);
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_MEMBER_DELETED, withdrawalDTO);
     }
 
     @Operation(summary = "[진행중인 스터디] 스터디 끝내기", description = """ 
@@ -40,7 +53,9 @@ public class MemberStudyController {
         로그인한 회원이 운영하는 특정 스터디에 대해 study status OFF로 전환합니다.
         """)
     @PatchMapping("/studies/{studyId}/termination")
-    public void terminateStudy(@PathVariable Long studyId) {
+    public ApiResponse<StudyTerminationResponseDTO.TerminationDTO> terminateStudy(@PathVariable Long studyId) {
+        StudyTerminationResponseDTO.TerminationDTO terminationDTO = memberStudyCommandService.terminateStudy(studyId);
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_TERMINATED, terminationDTO);
     }
 
     @Operation(summary = "[진행중인 스터디] 스터디 정보 수정하기", description = """ 

--- a/src/main/java/com/example/spot/web/controller/PostController.java
+++ b/src/main/java/com/example/spot/web/controller/PostController.java
@@ -3,7 +3,7 @@ package com.example.spot.web.controller;
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
 import com.example.spot.web.dto.post.*;
-import com.example.spot.web.service.PostService;
+import com.example.spot.service.post.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/example/spot/web/controller/StudyController.java
+++ b/src/main/java/com/example/spot/web/controller/StudyController.java
@@ -1,16 +1,28 @@
 package com.example.spot.web.controller;
 
-import com.example.spot.domain.enums.Gender;
-import com.example.spot.domain.enums.ThemeType;
+import com.example.spot.api.ApiResponse;
+import com.example.spot.api.code.status.SuccessStatus;
+import com.example.spot.service.study.StudyCommandService;
+import com.example.spot.service.study.StudyQueryService;
+import com.example.spot.web.dto.study.request.StudyJoinRequestDTO;
+import com.example.spot.web.dto.study.request.StudyRegisterRequestDTO;
+import com.example.spot.web.dto.study.response.StudyInfoResponseDTO;
+import com.example.spot.web.dto.study.response.StudyJoinResponseDTO;
+import com.example.spot.web.dto.study.response.StudyRegisterResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Study", description = "Study API")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/spot")
 public class StudyController {
+
+    private final StudyQueryService studyQueryService;
+    private final StudyCommandService studyCommandService;
 
 /* ----------------------------- 스터디 생성/참여 관련 API ------------------------------------- */
 
@@ -19,7 +31,9 @@ public class StudyController {
         스터디의 정보(이름, 참여인원, 찜 개수, 테마, 온라인 여부, 비용 여부, 연령 제한, 목표, 소개, 스터디장 등)가 반환됩니다.
         """)
     @GetMapping("/studies/{studyId}")
-    public void getStudyInfo(@PathVariable Long studyId) {
+    public ApiResponse<StudyInfoResponseDTO.StudyInfoDTO> getStudyInfo(@PathVariable Long studyId) {
+        StudyInfoResponseDTO.StudyInfoDTO studyInfoDTO = studyQueryService.getStudyInfo(studyId);
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studyInfoDTO);
     }
 
     @Operation(summary = "[스터디 생성/참여] 참여 신청하기", description = """ 
@@ -27,7 +41,10 @@ public class StudyController {
         로그인한 회원이 member_study에 application_status = APPLIED 상태로 추가됩니다.
         """)
     @PostMapping("/members/{memberId}/studies/{studyId}")
-    public void applyToStudy(@PathVariable Long memberId, @PathVariable Long studyId) {
+    public ApiResponse<StudyJoinResponseDTO.JoinDTO> applyToStudy(@PathVariable Long memberId, @PathVariable Long studyId,
+                                                                  @RequestBody StudyJoinRequestDTO.StudyJoinDTO studyJoinRequestDTO) {
+        StudyJoinResponseDTO.JoinDTO studyJoinResponseDTO = studyCommandService.applyToStudy(memberId, studyId, studyJoinRequestDTO);
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_MEMBER_CREATED, studyJoinResponseDTO);
     }
 
     @Operation(summary = "[스터디 생성/참여] 스터디 등록하기", description = """ 
@@ -35,7 +52,9 @@ public class StudyController {
         로그인한 회원이 owner인 새로운 스터디가 study에 생성됩니다.
         """)
     @PostMapping("/members/{memberId}/studies")
-    public void registerStudy(@PathVariable Long memberId) {
+    public ApiResponse<StudyRegisterResponseDTO.RegisterDTO> registerStudy(@PathVariable Long memberId, @RequestBody StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO) {
+        StudyRegisterResponseDTO.RegisterDTO studyRegisterResponseDTO = studyCommandService.registerStudy(memberId, studyRegisterRequestDTO);
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_CREATED, studyRegisterResponseDTO);
     }
 
 /* ----------------------------- 스터디 찜하기 관련 API ------------------------------------- */

--- a/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyTerminationResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyTerminationResponseDTO.java
@@ -1,0 +1,30 @@
+package com.example.spot.web.dto.memberstudy.response;
+
+import com.example.spot.domain.enums.Status;
+import com.example.spot.domain.study.Study;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public class StudyTerminationResponseDTO {
+
+    @Getter
+    @RequiredArgsConstructor
+    @Builder(access = AccessLevel.PRIVATE)
+    public static class TerminationDTO {
+
+        private final Long studyId;
+        private final String studyName;
+        private final Status status;
+
+        public static TerminationDTO toDTO(Study study) {
+            return TerminationDTO.builder()
+                    .studyId(study.getId())
+                    .studyName(study.getTitle())
+                    .status(study.getStatus())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyWithdrawalResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyWithdrawalResponseDTO.java
@@ -1,0 +1,32 @@
+package com.example.spot.web.dto.memberstudy.response;
+
+import com.example.spot.domain.Member;
+import com.example.spot.domain.study.Study;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public class StudyWithdrawalResponseDTO {
+
+    @Getter
+    @RequiredArgsConstructor
+    @Builder(access = AccessLevel.PRIVATE)
+    public static class WithdrawalDTO {
+
+        private final Long studyId;
+        private final String studyName;
+        private final Long memberId;
+        private final String memberName;
+
+        public static WithdrawalDTO toDTO(Member member, Study study) {
+            return WithdrawalDTO.builder()
+                    .studyId(study.getId())
+                    .studyName(study.getTitle())
+                    .memberId(member.getId())
+                    .memberName(member.getName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/spot/web/dto/study/request/StudyJoinRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/request/StudyJoinRequestDTO.java
@@ -1,0 +1,16 @@
+package com.example.spot.web.dto.study.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class StudyJoinRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StudyJoinDTO {
+        private String introduction;
+    }
+}

--- a/src/main/java/com/example/spot/web/dto/study/request/StudyRegisterRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/request/StudyRegisterRequestDTO.java
@@ -1,0 +1,41 @@
+package com.example.spot.web.dto.study.request;
+
+import com.example.spot.domain.enums.Gender;
+import com.example.spot.domain.enums.ThemeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+public class StudyRegisterRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegisterDTO {
+
+        private List<ThemeType> themes;
+        private String title;
+        private String goal;
+        private String introduction;
+        private Boolean isOnline;
+        private List<RegionDTO> regions;
+        private Long maxPeople;
+        private Gender gender;
+        private Integer minAge;
+        private Integer maxAge;
+        private Integer fee;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegionDTO {
+
+        private String province;
+        private String district;
+        private String neighborhood;
+    }
+}

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
@@ -1,0 +1,97 @@
+package com.example.spot.web.dto.study.response;
+
+import com.example.spot.domain.Member;
+import com.example.spot.domain.enums.Gender;
+import com.example.spot.domain.enums.ThemeType;
+import com.example.spot.domain.study.Study;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class StudyInfoResponseDTO {
+
+    @Getter
+    public static class StudyInfoDTO {
+
+        private final Long studyId;
+        private final String studyName;
+        private final StudyOwnerDTO studyOwner;
+        private final Long hitNum;
+        private final Integer heartCount;
+        private final Integer memberCount;
+        private final Gender gender;
+        private final Integer minAge;
+        private final Integer maxAge;
+        private final Integer fee;
+        private final Boolean isOnline;
+        private final List<ThemeType> themes;
+        private final String goal;
+        private final String introduction;
+
+        @Builder(access = AccessLevel.PRIVATE)
+        private StudyInfoDTO(Long studyId, String studyName, StudyOwnerDTO studyOwner,
+                             Long hitNum, Integer heartCount, Integer memberCount, Gender gender,
+                             Integer minAge, Integer maxAge, Integer fee, Boolean isOnline,
+                             List<ThemeType> themes, String goal, String introduction) {
+            this.studyId = studyId;
+            this.studyName = studyName;
+            this.studyOwner = studyOwner;
+            this.hitNum = hitNum;
+            this.heartCount = heartCount;
+            this.memberCount = memberCount;
+            this.gender = gender;
+            this.minAge = minAge;
+            this.maxAge = maxAge;
+            this.fee = fee;
+            this.isOnline = isOnline;
+            this.themes = themes;
+            this.goal = goal;
+            this.introduction = introduction;
+        }
+
+        public static StudyInfoDTO toDTO(Study study, Member member) {
+            return StudyInfoDTO.builder()
+                    .studyId(study.getId())
+                    .studyName(study.getTitle())
+                    .studyOwner(StudyOwnerDTO.toDTO(member))
+                    .hitNum(study.getHitNum())
+                    .heartCount(study.getHeartCount())
+                    .memberCount(study.getMemberStudies().size())
+                    .gender(study.getGender())
+                    .minAge(study.getMinAge())
+                    .maxAge(study.getMaxAge())
+                    .fee(study.getFee())
+                    .isOnline(study.getIsOnline())
+                    .themes(study.getStudyThemes().stream()
+                            .map(memberStudy -> { return memberStudy.getTheme().getStudyTheme();})
+                            .toList())
+                    .goal(study.getGoal())
+                    .introduction(study.getIntroduction())
+                    .build();
+        }
+    }
+
+    @Getter
+    private static class StudyOwnerDTO {
+
+        private final Long ownerId;
+        private final String ownerName;
+
+        @Builder
+        private StudyOwnerDTO(Long ownerId, String ownerName) {
+            this.ownerId = ownerId;
+            this.ownerName = ownerName;
+        }
+
+        public static StudyOwnerDTO toDTO(Member member) {
+            return StudyOwnerDTO.builder()
+                    .ownerId(member.getId())
+                    .ownerName(member.getName())
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyJoinResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyJoinResponseDTO.java
@@ -1,0 +1,51 @@
+package com.example.spot.web.dto.study.response;
+
+import com.example.spot.domain.Member;
+import com.example.spot.domain.study.Study;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StudyJoinResponseDTO {
+
+    @Getter
+    public static class JoinDTO {
+
+        private final Long memberId;
+        private final TitleDTO study;
+
+        @Builder(access = AccessLevel.PRIVATE)
+        private JoinDTO(Long memberId, TitleDTO study) {
+            this.memberId = memberId;
+            this.study = study;
+        }
+
+        public static JoinDTO toDTO(Member member, Study study) {
+            return JoinDTO.builder()
+                    .memberId(member.getId())
+                    .study(TitleDTO.toDTO(study))
+                    .build();
+        }
+    }
+
+    @Getter
+    private static class TitleDTO {
+
+        private final Long studyId;
+        private final String title;
+
+        @Builder(access = AccessLevel.PRIVATE)
+        private TitleDTO(Long studyId, String title) {
+            this.studyId = studyId;
+            this.title = title;
+        }
+
+        public static TitleDTO toDTO(Study study) {
+            return TitleDTO.builder()
+                    .studyId(study.getId())
+                    .title(study.getTitle())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyRegisterResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyRegisterResponseDTO.java
@@ -1,0 +1,30 @@
+package com.example.spot.web.dto.study.response;
+
+import com.example.spot.domain.study.Study;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StudyRegisterResponseDTO {
+
+    @Getter
+    public static class RegisterDTO {
+
+        private final Long studyId;
+        private final String title;
+
+        @Builder(access = AccessLevel.PRIVATE)
+        private RegisterDTO(Long studyId, String title) {
+            this.studyId = studyId;
+            this.title = title;
+        }
+
+        public static RegisterDTO toDTO(Study study) {
+            return RegisterDTO.builder()
+                    .studyId(study.getId())
+                    .title(study.getTitle())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #35 

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.

- [진행중인 스터디] 스터디 탈퇴하기
- [진행중인 스터디] 스터디 끝내기

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

이전 PR이랑 겹치는 코드들이 있습니다.
Feat/25의 기능을 사용해야 할 일이 있어서 한 번 rebase를 해서 그렇습니다...!!

진행중인 스터디 관련 기능은
[add] Create Repository for MemberStudyService 부분부터 리뷰해주시면 될 것 같아요~!
마찬가지로 아직 인증 관련 부분은 추가하지 않았습니다.
항상 꼼꼼한 리뷰 감사드립니다 👍🏻
