### PR TITLE
[FEAT] JWT 기반 Refresh Token 통한 세션 유지 기능 

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -17,9 +17,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON4002", "접근이 거부되었습니다."),
     _BAD_ENUM_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4003", "잘못된 열거형 요청입니다."),
     _INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON4004", "입력값이 유효하지 않습니다."),
-    _EMPTY_JWT(HttpStatus.BAD_REQUEST, "COMMON4005", "JWT is empty."),
-    _INVALID_JWT(HttpStatus.BAD_REQUEST, "COMMON4006", "Invalid JWT token."),
-    _EXPIRED_JWT(HttpStatus.BAD_REQUEST, "COMMON4007", "Expired JWT token."),
+    _EMPTY_JWT(HttpStatus.BAD_REQUEST, "COMMON4005", "JWT 토큰이 비어있습니다."),
+    _INVALID_JWT(HttpStatus.BAD_REQUEST, "COMMON4006", "유효하지 않은 JWT token입니다."),
+    _EXPIRED_JWT(HttpStatus.BAD_REQUEST, "COMMON4007", "만료된 JWT token입니다."),
+    _UNSUPPORTED_JWT(HttpStatus.BAD_REQUEST, "COMMON4008", "지원되지 않는 JWT token입니다."),
 
     //멤버 관련 에러
     _MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원을 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -21,6 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _INVALID_JWT(HttpStatus.BAD_REQUEST, "COMMON4006", "유효하지 않은 JWT token입니다."),
     _EXPIRED_JWT(HttpStatus.BAD_REQUEST, "COMMON4007", "만료된 JWT token입니다."),
     _UNSUPPORTED_JWT(HttpStatus.BAD_REQUEST, "COMMON4008", "지원되지 않는 JWT token입니다."),
+    _INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "COMMON4009", "유효하지 않은 리프레시 토큰입니다."),
+    _EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "COMMON4010", "만료된 리프레시 토큰입니다."),
 
     //멤버 관련 에러
     _MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원을 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBER_ID_NULL(HttpStatus.BAD_REQUEST, "MEMBER4003", "회원 아이디가 입력되지 않았습니다. "),
     _MEMBER_BIRTH_INVALID(HttpStatus.BAD_REQUEST, "MEMBER4005", "생년월일이 유효하지 않습니다."),
     _MEMBER_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4006", "이미 존재하는 이메일입니다."),
+    _MEMBER_NO_ACCESS(HttpStatus.FORBIDDEN, "MEMBER4007", "해당 API에 대한 접근 권한이 없습니다."),
 
     //스터디 관련 에러
     _STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4001", "스터디를 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/config/SwaggerConfig.java
+++ b/src/main/java/com/example/spot/config/SwaggerConfig.java
@@ -26,19 +26,18 @@ public class SwaggerConfig {
 
         // Define SecurityRequirement with both schemes
         SecurityRequirement securityRequirement = new SecurityRequirement()
-            .addList(jwtSchemeName)
-            .addList(refreshToken);
+            .addList(jwtSchemeName);
 
         Components components = new Components()
             .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
-                .bearerFormat("JWT"))
-            .addSecuritySchemes(refreshToken, new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY) // APIKEY 타입 사용
-                .in(SecurityScheme.In.HEADER)
-                .name("refreshToken")
-                .description("Refresh token"));
+                .bearerFormat("JWT"));
+//            .addSecuritySchemes(refreshToken, new SecurityScheme()
+//                .type(SecurityScheme.Type.APIKEY) // APIKEY 타입 사용
+//                .in(SecurityScheme.In.HEADER)
+//                .name("refreshToken")
+//                .description("Refresh token"));
 
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))

--- a/src/main/java/com/example/spot/config/SwaggerConfig.java
+++ b/src/main/java/com/example/spot/config/SwaggerConfig.java
@@ -1,10 +1,13 @@
 package com.example.spot.config;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,15 +22,23 @@ public class SwaggerConfig {
                 .description("SPOT API 명세서");
 
         String jwtSchemeName = "accessToken";
+        String refreshToken = "refreshToken";
 
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // Define SecurityRequirement with both schemes
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList(jwtSchemeName)
+            .addList(refreshToken);
 
         Components components = new Components()
-                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
-                        .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP)
-                        .scheme("bearer")
-                        .bearerFormat("JWT"));
+            .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT"))
+            .addSecuritySchemes(refreshToken, new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY) // APIKEY 타입 사용
+                .in(SecurityScheme.In.HEADER)
+                .name("refreshToken")
+                .description("Refresh token"));
 
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))

--- a/src/main/java/com/example/spot/config/WebSecurity.java
+++ b/src/main/java/com/example/spot/config/WebSecurity.java
@@ -1,8 +1,8 @@
 package com.example.spot.config;
 
 
-import com.example.spot.utils.jwt.JwtAuthenticationFilter;
-import com.example.spot.utils.jwt.JwtTokenProvider;
+import com.example.spot.security.filters.JwtAuthenticationFilter;
+import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/example/spot/config/WebSecurity.java
+++ b/src/main/java/com/example/spot/config/WebSecurity.java
@@ -32,6 +32,7 @@ public class WebSecurity {
                 .requestMatchers(new AntPathRequestMatcher("/spot/login/kakao", "GET")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/kakao", "GET")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/kakao/redirect", "GET")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/spot/member/test", "POST")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/api-docs")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/v3/**", "GET")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**", "GET")).permitAll()

--- a/src/main/java/com/example/spot/config/WebSecurity.java
+++ b/src/main/java/com/example/spot/config/WebSecurity.java
@@ -28,8 +28,8 @@ public class WebSecurity {
         http.csrf( (csrf) -> csrf.disable());
 
         http.authorizeHttpRequests((authz) -> authz
-                .requestMatchers(new AntPathRequestMatcher("/login")).permitAll()
-                .requestMatchers(new AntPathRequestMatcher("/spot/login", "GET")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/spot/reissue")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/spot/login/kakao", "GET")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/kakao", "GET")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/kakao/redirect", "GET")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/api-docs")).permitAll()

--- a/src/main/java/com/example/spot/domain/Member.java
+++ b/src/main/java/com/example/spot/domain/Member.java
@@ -78,6 +78,9 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Column(nullable = false)
+    private String refreshToken;
+
     //== 스터디 희망사유 ==//
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     @Builder.Default
@@ -278,6 +281,10 @@ public class Member extends BaseEntity {
 
     public void addComment(StudyPostComment studyPostComment) {
         this.studyPostCommentList.add(studyPostComment);
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
 

--- a/src/main/java/com/example/spot/domain/Member.java
+++ b/src/main/java/com/example/spot/domain/Member.java
@@ -78,9 +78,6 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    @Column(nullable = false)
-    private String refreshToken;
-
     //== 스터디 희망사유 ==//
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     @Builder.Default
@@ -282,10 +279,5 @@ public class Member extends BaseEntity {
     public void addComment(StudyPostComment studyPostComment) {
         this.studyPostCommentList.add(studyPostComment);
     }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
 
 }

--- a/src/main/java/com/example/spot/domain/Member.java
+++ b/src/main/java/com/example/spot/domain/Member.java
@@ -30,6 +30,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "members")
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/spot/domain/auth/CustomUserDetails.java
+++ b/src/main/java/com/example/spot/domain/auth/CustomUserDetails.java
@@ -15,8 +15,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CustomUserDetails implements UserDetails {
 
-    private Long memberId; // 사용자 고유 ID
-    private String username; // 사용자 이름
+    private String email; // 사용자 email
+    private Long memberId; // 사용자 이름
     private String password; // 비밀번호
     private boolean enabled; // 계정 활성화 여부
     private Collection<? extends GrantedAuthority> authorities; // 사용자 권한
@@ -33,7 +33,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return username;
+        return memberId.toString();
     }
 
     @Override

--- a/src/main/java/com/example/spot/domain/auth/CustomUserDetails.java
+++ b/src/main/java/com/example/spot/domain/auth/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package com.example.spot.domain.auth;
+
+import java.util.Collection;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomUserDetails implements UserDetails {
+
+    private Long memberId; // 사용자 고유 ID
+    private String username; // 사용자 이름
+    private String password; // 비밀번호
+    private boolean enabled; // 계정 활성화 여부
+    private Collection<? extends GrantedAuthority> authorities; // 사용자 권한
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/example/spot/domain/auth/RefreshToken.java
+++ b/src/main/java/com/example/spot/domain/auth/RefreshToken.java
@@ -1,0 +1,31 @@
+package com.example.spot.domain.auth;
+
+import com.example.spot.domain.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@DynamicUpdate
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RefreshToken extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long memberId;
+    private String token;
+
+}

--- a/src/main/java/com/example/spot/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/spot/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.auth.RefreshToken;
+import com.example.spot.domain.study.Option;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long>{
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.example.spot.security.filters;
 
+import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.GeneralException;
 import com.example.spot.service.member.MemberService;
 import com.example.spot.security.utils.JwtTokenProvider;
@@ -8,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -28,9 +30,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
         try {
-            //log.info(request.getRequestURI());
             String token = jwtTokenProvider.resolveToken(request);
-            log.info("token : " + token);
+            if (Objects.equals(request.getRequestURI(), "/spot/reissue")){
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             if (token != null && jwtTokenProvider.validateToken(token)) {
                 Long memberId = jwtTokenProvider.getMemberIdByToken(token);
                 UserDetails userDetails = memberService.loadUserByUsername(memberId.toString()); // UserDetails 조회

--- a/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
@@ -30,6 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             //log.info(request.getRequestURI());
             String token = jwtTokenProvider.resolveToken(request);
+            log.info("token : " + token);
             if (token != null && jwtTokenProvider.validateToken(token)) {
                 Long memberId = jwtTokenProvider.getMemberIdByToken(token);
                 UserDetails userDetails = memberService.loadUserByUsername(memberId.toString()); // UserDetails 조회
@@ -38,7 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
             filterChain.doFilter(request, response);
         }catch (GeneralException e){
-            response.setContentType("text/plain");
+            response.setContentType("text/plain; charset=UTF-8");
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 
             try (PrintWriter writer = response.getWriter()) {

--- a/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
@@ -1,7 +1,8 @@
-package com.example.spot.utils.jwt;
+package com.example.spot.security.filters;
 
 import com.example.spot.api.exception.GeneralException;
 import com.example.spot.service.member.MemberService;
+import com.example.spot.security.utils.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.parameters.P;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 

--- a/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
@@ -31,8 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             //log.info(request.getRequestURI());
             String token = jwtTokenProvider.resolveToken(request);
             if (token != null && jwtTokenProvider.validateToken(token)) {
-                String email = jwtTokenProvider.getUserPk(token);
-                UserDetails userDetails = memberService.loadUserByUsername(email); // UserDetails 조회
+                Long memberId = jwtTokenProvider.getMemberIdByToken(token);
+                UserDetails userDetails = memberService.loadUserByUsername(memberId.toString()); // UserDetails 조회
                 Authentication authentication = jwtTokenProvider.getAuthentication(token, userDetails);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.example.spot.security.filters;
 
 import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.GeneralException;
+import com.example.spot.domain.auth.CustomUserDetails;
 import com.example.spot.service.member.MemberService;
 import com.example.spot.security.utils.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
@@ -53,8 +54,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private void authenticateUser(String token) {
         Long memberId = jwtTokenProvider.getMemberIdByToken(token);
-        UserDetails userDetails = memberService.loadUserByUsername(memberId.toString());
+        CustomUserDetails userDetails = (CustomUserDetails) memberService.loadUserByUsername(memberId.toString());
         Authentication authentication = jwtTokenProvider.getAuthentication(token, userDetails);
+        log.info("Authenticated user: {}", userDetails.getUsername());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.example.spot.utils.jwt;
+package com.example.spot.security.utils;
 
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.ErrorStatus;

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -36,6 +36,7 @@ public class JwtTokenProvider {
         JWT_SECRET_KEY = Base64.getEncoder().encodeToString(JWT_SECRET_KEY.getBytes(StandardCharsets.UTF_8));
     }
 
+    // 액세스 및 리프레시 토큰 생성
     public TokenDTO createToken(Long memberId) {
         Date now = new Date();
         String accessToken = generateToken(memberId, now, ACCESS_TOKEN_EXPIRATION_TIME);
@@ -48,6 +49,7 @@ public class JwtTokenProvider {
             .build();
     }
 
+    // JWT 토큰 생성 -> 위 createToken 메서드에서 호출
     private String generateToken(Long memberId, Date now, long expirationTime) {
         return Jwts.builder()
             .claim("memberId", memberId)
@@ -57,14 +59,17 @@ public class JwtTokenProvider {
             .compact();
     }
 
+    // 토큰 유효성 검사 -> 유효기간 만료 여부 확인
     public boolean isTokenExpired(String token) {
         return validateToken(token, true) == ErrorStatus._EXPIRED_JWT;
     }
 
+    // 토큰 유효성 검사 -> 외부 호출 용
     public boolean validateToken(String token) {
         return validateToken(token, false) == null;
     }
 
+    // 토큰 유효성 검사
     private ErrorStatus validateToken(String token, boolean checkExpirationOnly) {
         try {
             Jwts.parserBuilder().setSigningKey(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes())).build().parseClaimsJws(token);

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -104,14 +104,9 @@ public class JwtTokenProvider {
         return request.getHeader("refreshToken");
     }
 
-    public String getUserPk(String token) {
-        return Jwts.parser().setSigningKey(JWT_SECRET_KEY).parseClaimsJws(token).getBody().getSubject();
-    }
-
     public TokenDTO reissueToken(String refreshToken) {
         Claims claims = Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(refreshToken).getBody();
         Long memberId = claims.get("memberId", Long.class);
-
         return createToken(memberId);
     }
 

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -108,4 +108,8 @@ public class JwtTokenProvider {
 
         return createToken(memberId);
     }
+
+    public Long getMemberIdByToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(token).getBody().get("memberId", Long.class);
+    }
 }

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -59,9 +59,9 @@ public class JwtTokenProvider {
             .build();
     }
 
-    public boolean isRefreshTokenExpired(String refreshToken) {
+    public boolean isTokenExpired(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(refreshToken);
+            Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(token);
             return false;
         } catch (ExpiredJwtException e) {
             return true;
@@ -99,6 +99,9 @@ public class JwtTokenProvider {
         }
         // "Bearer " 접두사 제거 후 토큰 반환
         return authorization.substring("Bearer ".length()).trim();
+    }
+    public String resolveRefreshToken(HttpServletRequest request) {
+        return request.getHeader("refreshToken");
     }
 
     public String getUserPk(String token) {

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -59,6 +59,15 @@ public class JwtTokenProvider {
             .build();
     }
 
+    public boolean isRefreshTokenExpired(String refreshToken) {
+        try {
+            Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(refreshToken);
+            return false;
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
+
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(token);
@@ -91,5 +100,12 @@ public class JwtTokenProvider {
 
     public String getUserPk(String token) {
         return Jwts.parser().setSigningKey(JWT_SECRET_KEY).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public TokenDTO reissueToken(String refreshToken) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(refreshToken).getBody();
+        Long memberId = claims.get("memberId", Long.class);
+
+        return createToken(memberId);
     }
 }

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -24,7 +24,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    @Value("${jwt.secret}")
+    @Value("${token.access_secret}")
     private String JWT_SECRET_KEY;
     @Value("${token.access_token_expiration_time}")
     private Long ACCESS_TOKEN_EXPIRATION_TIME;
@@ -39,8 +39,8 @@ public class JwtTokenProvider {
     // 액세스 및 리프레시 토큰 생성
     public TokenDTO createToken(Long memberId) {
         Date now = new Date();
-        String accessToken = generateToken(memberId, now, ACCESS_TOKEN_EXPIRATION_TIME);
-        String refreshToken = generateToken(memberId, now, REFRESH_TOKEN_EXPIRATION_TIME);
+        String accessToken = generateToken(memberId, now, ACCESS_TOKEN_EXPIRATION_TIME, "access");
+        String refreshToken = generateToken(memberId, now, REFRESH_TOKEN_EXPIRATION_TIME, "refresh");
 
         return TokenDTO.builder()
             .accessToken(accessToken)
@@ -50,9 +50,10 @@ public class JwtTokenProvider {
     }
 
     // JWT 토큰 생성 -> 위 createToken 메서드에서 호출
-    private String generateToken(Long memberId, Date now, long expirationTime) {
+    private String generateToken(Long memberId, Date now, long expirationTime, String tokenType) {
         return Jwts.builder()
             .claim("memberId", memberId)
+            .claim("tokenType", tokenType)
             .setIssuedAt(now)
             .setExpiration(new Date(now.getTime() + expirationTime))
             .signWith(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -73,15 +73,18 @@ public class JwtTokenProvider {
             Jwts.parserBuilder().setSigningKey(JWT_SECRET_KEY).build().parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT Token", e);
+            log.info("Invalid JWT Token : {}", e.getMessage());
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
         } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token", e);
+            log.info("Expired JWT Token : {}", e.getMessage());
+            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
         } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token", e);
+            log.info("Unsupported JWT Token : {}", e.getMessage());
+            throw new GeneralException(ErrorStatus._UNSUPPORTED_JWT);
         } catch (IllegalArgumentException e) {
-            log.info("JWT claims string is empty.", e);
+            log.info("JWT claims string is empty. : {}", e.getMessage());
+            throw new GeneralException(ErrorStatus._EMPTY_JWT);
         }
-        return false;
     }
 
     public Authentication getAuthentication(String token, UserDetails userDetails) {

--- a/src/main/java/com/example/spot/security/utils/SecurityUtils.java
+++ b/src/main/java/com/example/spot/security/utils/SecurityUtils.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityUtils {
 
+    // 현재 인증된 사용자의 ID를 반환
     public static Long getCurrentUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
@@ -16,6 +17,7 @@ public class SecurityUtils {
         return Long.valueOf(authentication.getName());
     }
 
+    // 현재 인증된 사용자의 ID와 매개변수로 전달된 ID가 일치하는지 확인
     public static void verifyUserId(Long memberId) {
         Long currentUserId = getCurrentUserId();
         if (!Objects.equals(currentUserId, memberId)) {

--- a/src/main/java/com/example/spot/security/utils/SecurityUtils.java
+++ b/src/main/java/com/example/spot/security/utils/SecurityUtils.java
@@ -1,0 +1,26 @@
+package com.example.spot.security.utils;
+
+import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.GeneralException;
+import java.util.Objects;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+        return Long.valueOf(authentication.getName());
+    }
+
+    public static void verifyUserId(Long memberId) {
+        Long currentUserId = getCurrentUserId();
+        if (!Objects.equals(currentUserId, memberId)) {
+            throw new GeneralException(ErrorStatus._MEMBER_NO_ACCESS);
+        }
+    }
+
+}

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -1,69 +1,10 @@
 package com.example.spot.service.auth;
 
-
-import com.example.spot.api.code.status.ErrorStatus;
-import com.example.spot.api.exception.GeneralException;
-import com.example.spot.domain.Member;
-import com.example.spot.domain.auth.RefreshToken;
-import com.example.spot.repository.MemberRepository;
-import com.example.spot.repository.RefreshTokenRepository;
-import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
-import java.time.Instant;
-import java.util.Objects;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@Slf4j
-@RequiredArgsConstructor
-@Transactional
-public class AuthService {
+public interface AuthService {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final MemberRepository memberRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
-
-    public TokenDTO reissueToken(String refreshToken) {
-        // 리프레시 토큰 추출
-        log.info("refreshToken: {}", refreshToken);
-
-        // 리프레시 토큰 조회 및 검증
-        RefreshToken tokenInDB = refreshTokenRepository.findByToken(refreshToken)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_REFRESH_TOKEN));
-
-        if (jwtTokenProvider.isTokenExpired(tokenInDB.getToken())) {
-            refreshTokenRepository.delete(tokenInDB);
-            throw new GeneralException(ErrorStatus._EXPIRED_REFRESH_TOKEN);
-        }
-
-        // 리프레시 토큰에서 memberId 추출
-        Long memberIdByToken = jwtTokenProvider.getMemberIdByToken(refreshToken);
-
-        // memberId로 회원 조회
-        Member member = memberRepository.findById(memberIdByToken)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
-        // 회원의 리프레시 토큰과 요청된 리프레시 토큰 비교
-        if (!Objects.equals(member.getId(), memberIdByToken))
-            throw new GeneralException(ErrorStatus._INVALID_JWT);
-
-        TokenDTO tokenDTO = jwtTokenProvider.reissueToken(refreshToken);
-
-        RefreshToken token = RefreshToken.builder()
-            .memberId(member.getId())
-            .token(tokenDTO.getRefreshToken())
-            .build();
-
-        if (refreshTokenRepository.existsByMemberId(member.getId()))
-            refreshTokenRepository.deleteByMemberId(member.getId());
-
-        refreshTokenRepository.save(token);
-
-        // 토큰 재발급
-        return tokenDTO;
-    }
+    // 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급
+    TokenDTO reissueToken(String refreshToken);
 
 }

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -1,14 +1,15 @@
-package com.example.spot.service.oauth;
+package com.example.spot.service.auth;
 
 
 import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.GeneralException;
 import com.example.spot.domain.Member;
+import com.example.spot.domain.auth.RefreshToken;
 import com.example.spot.repository.MemberRepository;
+import com.example.spot.repository.RefreshTokenRepository;
 import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
-import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
+import java.time.Instant;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,14 +24,20 @@ public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public TokenDTO reissueToken(String refreshToken) {
         // 리프레시 토큰 추출
         log.info("refreshToken: {}", refreshToken);
 
-        // 리프레시 토큰 만료 여부 확인
-        if (jwtTokenProvider.isTokenExpired(refreshToken))
-            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+        // 리프레시 토큰 조회 및 검증
+        RefreshToken tokenInDB = refreshTokenRepository.findByToken(refreshToken)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_REFRESH_TOKEN));
+
+        if (jwtTokenProvider.isTokenExpired(tokenInDB.getToken())) {
+            refreshTokenRepository.delete(tokenInDB);
+            throw new GeneralException(ErrorStatus._EXPIRED_REFRESH_TOKEN);
+        }
 
         // 리프레시 토큰에서 memberId 추출
         Long memberIdByToken = jwtTokenProvider.getMemberIdByToken(refreshToken);
@@ -44,7 +51,17 @@ public class AuthService {
             throw new GeneralException(ErrorStatus._INVALID_JWT);
 
         TokenDTO tokenDTO = jwtTokenProvider.reissueToken(refreshToken);
-        member.updateRefreshToken(tokenDTO.getRefreshToken());
+
+        RefreshToken token = RefreshToken.builder()
+            .memberId(member.getId())
+            .token(tokenDTO.getRefreshToken())
+            .build();
+
+        if (refreshTokenRepository.existsByMemberId(member.getId()))
+            refreshTokenRepository.deleteByMemberId(member.getId());
+
+        refreshTokenRepository.save(token);
+
         // 토큰 재발급
         return tokenDTO;
     }

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -1,0 +1,70 @@
+package com.example.spot.service.auth;
+
+
+import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.GeneralException;
+import com.example.spot.domain.Member;
+import com.example.spot.domain.auth.RefreshToken;
+import com.example.spot.repository.MemberRepository;
+import com.example.spot.repository.RefreshTokenRepository;
+import com.example.spot.security.utils.JwtTokenProvider;
+import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
+import java.time.Instant;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class AuthServiceImpl implements AuthService{
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public TokenDTO reissueToken(String refreshToken) {
+        // 리프레시 토큰 추출
+        log.info("refreshToken: {}", refreshToken);
+
+        // 리프레시 토큰 조회 및 검증
+        RefreshToken tokenInDB = refreshTokenRepository.findByToken(refreshToken)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_REFRESH_TOKEN));
+
+        if (jwtTokenProvider.isTokenExpired(tokenInDB.getToken())) {
+            refreshTokenRepository.delete(tokenInDB);
+            throw new GeneralException(ErrorStatus._EXPIRED_REFRESH_TOKEN);
+        }
+
+        // 리프레시 토큰에서 memberId 추출
+        Long memberIdByToken = jwtTokenProvider.getMemberIdByToken(refreshToken);
+
+        // memberId로 회원 조회
+        Member member = memberRepository.findById(memberIdByToken)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        // 회원의 리프레시 토큰과 요청된 리프레시 토큰 비교
+        if (!Objects.equals(member.getId(), memberIdByToken))
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+
+        TokenDTO tokenDTO = jwtTokenProvider.reissueToken(refreshToken);
+
+        RefreshToken token = RefreshToken.builder()
+            .memberId(member.getId())
+            .token(tokenDTO.getRefreshToken())
+            .build();
+
+        if (refreshTokenRepository.existsByMemberId(member.getId()))
+            refreshTokenRepository.deleteByMemberId(member.getId());
+
+        refreshTokenRepository.save(token);
+
+        // 토큰 재발급
+        return tokenDTO;
+    }
+
+}

--- a/src/main/java/com/example/spot/service/auth/KaKaoOAuthService.java
+++ b/src/main/java/com/example/spot/service/auth/KaKaoOAuthService.java
@@ -1,4 +1,4 @@
-package com.example.spot.service.oauth;
+package com.example.spot.service.auth;
 
 import com.example.spot.web.dto.member.kakao.KaKaoOAuthToken;
 import com.example.spot.web.dto.member.kakao.KaKaoOAuthToken.KaKaoOAuthTokenDTO;

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -76,7 +76,7 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
             // JWT 토큰 생성
-            String token = jwtTokenProvider.createToken(member.getEmail());
+            String token = jwtTokenProvider.createAccessToken(member.getEmail());
 
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
@@ -89,7 +89,7 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.save(kaKaoUser.toMember());
 
         // JWT 토큰 생성
-        String token = jwtTokenProvider.createToken(member.getEmail());
+        String token = jwtTokenProvider.createAccessToken(member.getEmail());
 
         // 회원 가입 DTO 반환
         return MemberSignInDTO.builder()
@@ -180,7 +180,7 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
             // JWT 토큰 생성
-            String token = jwtTokenProvider.createToken(member.getEmail());
+            String token = jwtTokenProvider.createAccessToken(member.getEmail());
 
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
@@ -193,7 +193,7 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.save(kaKaoUser.toMember());
 
         // JWT 토큰 생성
-        String token = jwtTokenProvider.createToken(member.getEmail());
+        String token = jwtTokenProvider.createAccessToken(member.getEmail());
 
         // 회원 가입 DTO 반환
         return MemberResponseDTO.MemberSignInDTO.builder()

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -92,13 +92,7 @@ public class MemberServiceImpl implements MemberService {
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
-            RefreshToken refreshToken = RefreshToken.builder()
-                .memberId(member.getId())
-                .token(token.getRefreshToken())
-                .build();
-
-            // 리프레시 토큰 저장
-            refreshTokenRepository.save(refreshToken);
+            saveRefreshToken(member, token);
 
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
@@ -115,14 +109,7 @@ public class MemberServiceImpl implements MemberService {
         // JWT 토큰 생성
         TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
-        RefreshToken refreshToken = RefreshToken.builder()
-            .memberId(member.getId())
-            .token(token.getRefreshToken())
-            .build();
-
-        // 리프레시 토큰 저장
-        refreshTokenRepository.save(refreshToken);
-
+        saveRefreshToken(member, token);
 
         // 회원 가입 DTO 반환
         return MemberResponseDTO.MemberSignInDTO.builder()
@@ -130,6 +117,16 @@ public class MemberServiceImpl implements MemberService {
             .memberId(member.getId())
             .email(member.getEmail())
             .build();
+    }
+
+    private void saveRefreshToken(Member member, TokenDTO token) {
+        RefreshToken refreshToken = RefreshToken.builder()
+            .memberId(member.getId())
+            .token(token.getRefreshToken())
+            .build();
+
+        // 리프레시 토큰 저장
+        refreshTokenRepository.save(refreshToken);
     }
 
 
@@ -217,12 +214,7 @@ public class MemberServiceImpl implements MemberService {
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
-            RefreshToken refreshToken = RefreshToken.builder()
-                .memberId(member.getId())
-                .token(token.getRefreshToken())
-                .build();
-
-            refreshTokenRepository.save(refreshToken);
+            saveRefreshToken(member, token);
 
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
@@ -238,12 +230,7 @@ public class MemberServiceImpl implements MemberService {
         // JWT 토큰 생성
         TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
-        RefreshToken refreshToken = RefreshToken.builder()
-            .memberId(member.getId())
-            .token(token.getRefreshToken())
-            .build();
-
-        refreshTokenRepository.save(refreshToken);
+        saveRefreshToken(member, token);
 
         // 회원 가입 DTO 반환
         return MemberResponseDTO.MemberSignInDTO.builder()
@@ -326,13 +313,20 @@ public class MemberServiceImpl implements MemberService {
             .isAdmin(false)
             .status(Status.ON)
             .build();
+
         memberRepository.save(member);
+
         updateTheme(member.getId(), requestDTO.getThemes());
         updateRegion(member.getId(), requestDTO.getRegions());
+
+        TokenDTO token = jwtTokenProvider.createToken(member.getId());
+
+        saveRefreshToken(member, token);
 
         return MemberTestDTO.builder()
             .memberId(member.getId())
             .email(member.getEmail())
+            .tokens(token)
             .build();
     }
 

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -14,6 +14,7 @@ import com.example.spot.web.dto.member.MemberResponseDTO.MemberSignInDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberTestDTO;
 import com.example.spot.web.dto.member.kakao.KaKaoOAuthToken.KaKaoOAuthTokenDTO;
 import com.example.spot.web.dto.member.kakao.KaKaoUser;
+import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -76,11 +77,12 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
             // JWT 토큰 생성
-            String token = jwtTokenProvider.createAccessToken(member.getEmail());
+            TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
-                .accessToken(token)
+                .tokens(token)
+                .memberId(member.getId())
                 .email(member.getEmail())
                 .build();
         }
@@ -89,12 +91,14 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.save(kaKaoUser.toMember());
 
         // JWT 토큰 생성
-        String token = jwtTokenProvider.createAccessToken(member.getEmail());
+        TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
         // 회원 가입 DTO 반환
-        return MemberSignInDTO.builder()
-            .accessToken(token)
-            .email(member.getEmail()).build();
+        return MemberResponseDTO.MemberSignInDTO.builder()
+            .tokens(token)
+            .memberId(member.getId())
+            .email(member.getEmail())
+            .build();
     }
 
 
@@ -180,11 +184,12 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
             // JWT 토큰 생성
-            String token = jwtTokenProvider.createAccessToken(member.getEmail());
+            TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
-                .accessToken(token)
+                .tokens(token)
+                .memberId(member.getId())
                 .email(member.getEmail())
                 .build();
         }
@@ -193,11 +198,12 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.save(kaKaoUser.toMember());
 
         // JWT 토큰 생성
-        String token = jwtTokenProvider.createAccessToken(member.getEmail());
+        TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
         // 회원 가입 DTO 반환
         return MemberResponseDTO.MemberSignInDTO.builder()
-            .accessToken(token)
+            .tokens(token)
+            .memberId(member.getId())
             .email(member.getEmail())
             .build();
     }

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -219,7 +219,8 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(username)
+        Long memberId = parseUsernameToMemberId(username);
+        Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
         List<GrantedAuthority> authorities = List.of(
@@ -292,6 +293,15 @@ public class MemberServiceImpl implements MemberService {
             .memberId(member.getId())
             .email(member.getEmail())
             .build();
+    }
+
+
+    private Long parseUsernameToMemberId(String username) {
+        try {
+            return Long.parseLong(username);
+        } catch (NumberFormatException e) {
+            throw new UsernameNotFoundException("Invalid user ID format");
+        }
     }
 
 }

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -83,6 +83,7 @@ public class MemberServiceImpl implements MemberService {
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
+            member.updateRefreshToken(token.getRefreshToken());
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
                 .tokens(token)
@@ -91,12 +92,15 @@ public class MemberServiceImpl implements MemberService {
                 .build();
         }
 
+
         // 존재하지 않는 경우, 새로운 회원 정보 저장
         Member member = memberRepository.save(kaKaoUser.toMember());
 
         // JWT 토큰 생성
         TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
+        member.updateRefreshToken(token.getRefreshToken());
+        memberRepository.save(member);
         // 회원 가입 DTO 반환
         return MemberResponseDTO.MemberSignInDTO.builder()
             .tokens(token)
@@ -190,6 +194,8 @@ public class MemberServiceImpl implements MemberService {
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
+            member.updateRefreshToken(token.getRefreshToken());
+
             // 로그인 DTO 반환
             return MemberResponseDTO.MemberSignInDTO.builder()
                 .tokens(token)
@@ -203,7 +209,7 @@ public class MemberServiceImpl implements MemberService {
 
         // JWT 토큰 생성
         TokenDTO token = jwtTokenProvider.createToken(member.getId());
-
+        member.updateRefreshToken(token.getRefreshToken());
         // 회원 가입 DTO 반환
         return MemberResponseDTO.MemberSignInDTO.builder()
             .tokens(token)

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -234,8 +234,8 @@ public class MemberServiceImpl implements MemberService {
         );
 
         return CustomUserDetails.builder()
+            .email(member.getEmail())
             .memberId(member.getId())
-            .username(member.getEmail())
             .password(member.getPassword())
             .enabled(true)
             .authorities(authorities)

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -7,8 +7,12 @@ import com.example.spot.domain.enums.Status;
 import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.domain.Member;
 import com.example.spot.repository.MemberRepository;
-import com.example.spot.service.member.oauth.KaKaoOAuthService;
 import com.example.spot.web.dto.member.MemberRequestDTO.TestMemberDTO;
+import com.example.spot.domain.auth.CustomUserDetails;
+import com.example.spot.security.utils.JwtTokenProvider;
+import com.example.spot.domain.Member;
+import com.example.spot.repository.MemberRepository;
+import com.example.spot.service.oauth.KaKaoOAuthService;
 import com.example.spot.web.dto.member.MemberResponseDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberSignInDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberTestDTO;
@@ -222,9 +226,13 @@ public class MemberServiceImpl implements MemberService {
             new SimpleGrantedAuthority("ROLE_" + (member.getIsAdmin() ? "ADMIN" : "USER"))
         );
 
-        return new User(member.getEmail(), member.getPassword(),
-            true, true,
-            true, true, authorities);
+        return CustomUserDetails.builder()
+            .memberId(member.getId())
+            .username(member.getEmail())
+            .password(member.getPassword())
+            .enabled(true)
+            .authorities(authorities)
+            .build();
     }
 
     @Override

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -4,7 +4,7 @@ import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.GeneralException;
 import com.example.spot.domain.enums.Carrier;
 import com.example.spot.domain.enums.Status;
-import com.example.spot.utils.jwt.JwtTokenProvider;
+import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.domain.Member;
 import com.example.spot.repository.MemberRepository;
 import com.example.spot.service.member.oauth.KaKaoOAuthService;

--- a/src/main/java/com/example/spot/service/oauth/AuthService.java
+++ b/src/main/java/com/example/spot/service/oauth/AuthService.java
@@ -1,0 +1,28 @@
+package com.example.spot.service.oauth;
+
+
+import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.GeneralException;
+import com.example.spot.repository.MemberRepository;
+import com.example.spot.security.utils.JwtTokenProvider;
+import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    public TokenDTO reissueToken(String refreshToken) {
+        if (jwtTokenProvider.isRefreshTokenExpired(refreshToken))
+            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+
+        return jwtTokenProvider.reissueToken(refreshToken);
+    }
+
+}

--- a/src/main/java/com/example/spot/service/oauth/AuthService.java
+++ b/src/main/java/com/example/spot/service/oauth/AuthService.java
@@ -24,9 +24,8 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
 
-    public TokenDTO reissueToken(HttpServletRequest request) {
+    public TokenDTO reissueToken(String refreshToken) {
         // 리프레시 토큰 추출
-        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
         log.info("refreshToken: {}", refreshToken);
 
         // 리프레시 토큰 만료 여부 확인

--- a/src/main/java/com/example/spot/service/oauth/AuthService.java
+++ b/src/main/java/com/example/spot/service/oauth/AuthService.java
@@ -7,6 +7,7 @@ import com.example.spot.domain.Member;
 import com.example.spot.repository.MemberRepository;
 import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +24,13 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
 
-    public TokenDTO reissueToken(String refreshToken) {
+    public TokenDTO reissueToken(HttpServletRequest request) {
+        // 리프레시 토큰 추출
+        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+        log.info("refreshToken: {}", refreshToken);
+
         // 리프레시 토큰 만료 여부 확인
-        if (jwtTokenProvider.isRefreshTokenExpired(refreshToken))
+        if (jwtTokenProvider.isTokenExpired(refreshToken))
             throw new GeneralException(ErrorStatus._EXPIRED_JWT);
 
         // 리프레시 토큰에서 memberId 추출
@@ -36,11 +41,13 @@ public class AuthService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
         // 회원의 리프레시 토큰과 요청된 리프레시 토큰 비교
-        if (!Objects.equals(member.getRefreshToken(), refreshToken))
+        if (!Objects.equals(member.getId(), memberIdByToken))
             throw new GeneralException(ErrorStatus._INVALID_JWT);
 
+        TokenDTO tokenDTO = jwtTokenProvider.reissueToken(refreshToken);
+        member.updateRefreshToken(tokenDTO.getRefreshToken());
         // 토큰 재발급
-        return jwtTokenProvider.reissueToken(refreshToken);
+        return tokenDTO;
     }
 
 }

--- a/src/main/java/com/example/spot/service/oauth/AuthService.java
+++ b/src/main/java/com/example/spot/service/oauth/AuthService.java
@@ -3,9 +3,12 @@ package com.example.spot.service.oauth;
 
 import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.GeneralException;
+import com.example.spot.domain.Member;
 import com.example.spot.repository.MemberRepository;
 import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,9 +22,22 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     public TokenDTO reissueToken(String refreshToken) {
+        // 리프레시 토큰 만료 여부 확인
         if (jwtTokenProvider.isRefreshTokenExpired(refreshToken))
             throw new GeneralException(ErrorStatus._EXPIRED_JWT);
 
+        // 리프레시 토큰에서 memberId 추출
+        Long memberIdByToken = jwtTokenProvider.getMemberIdByToken(refreshToken);
+
+        // memberId로 회원 조회
+        Member member = memberRepository.findById(memberIdByToken)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        // 회원의 리프레시 토큰과 요청된 리프레시 토큰 비교
+        if (!Objects.equals(member.getRefreshToken(), refreshToken))
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+
+        // 토큰 재발급
         return jwtTokenProvider.reissueToken(refreshToken);
     }
 

--- a/src/main/java/com/example/spot/service/oauth/AuthService.java
+++ b/src/main/java/com/example/spot/service/oauth/AuthService.java
@@ -12,10 +12,12 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class AuthService {
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/example/spot/service/oauth/KaKaoOAuthService.java
+++ b/src/main/java/com/example/spot/service/oauth/KaKaoOAuthService.java
@@ -1,4 +1,4 @@
-package com.example.spot.service.member.oauth;
+package com.example.spot.service.oauth;
 
 import com.example.spot.web.dto.member.kakao.KaKaoOAuthToken;
 import com.example.spot.web.dto.member.kakao.KaKaoOAuthToken.KaKaoOAuthTokenDTO;

--- a/src/main/java/com/example/spot/validation/validator/MemberValidator.java
+++ b/src/main/java/com/example/spot/validation/validator/MemberValidator.java
@@ -1,0 +1,14 @@
+package com.example.spot.validation.validator;
+
+import com.example.spot.security.utils.JwtTokenProvider;
+
+public class MemberValidator {
+    private static JwtTokenProvider jwtTokenProvider;
+
+    public static void validateMember (String token, Long memberId) {
+        Long tokenUserId = jwtTokenProvider.getMemberIdByToken(token);
+        if (!tokenUserId.equals(memberId)) {
+            throw new SecurityException("User ID does not match");
+        }
+    }
+}

--- a/src/main/java/com/example/spot/web/AuthController.java
+++ b/src/main/java/com/example/spot/web/AuthController.java
@@ -1,0 +1,27 @@
+package com.example.spot.web;
+
+import com.example.spot.api.ApiResponse;
+import com.example.spot.api.code.status.SuccessStatus;
+import com.example.spot.security.utils.JwtTokenProvider;
+import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "Auth API")
+@RestController
+@RequestMapping("/spot")
+@RequiredArgsConstructor
+public class AuthController {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/reissue")
+    public ApiResponse<TokenDTO> reissueToken(@RequestHeader String refreshToken) {
+        return ApiResponse.onSuccess(SuccessStatus._CREATED, jwtTokenProvider.reissueToken(refreshToken));
+    }
+
+
+}

--- a/src/main/java/com/example/spot/web/AuthController.java
+++ b/src/main/java/com/example/spot/web/AuthController.java
@@ -3,7 +3,10 @@ package com.example.spot.web;
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
 import com.example.spot.security.utils.JwtTokenProvider;
+import com.example.spot.service.oauth.AuthService;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,12 +19,58 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/spot")
 @RequiredArgsConstructor
 public class AuthController {
-    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthService authService;
 
+    @Operation(summary = "[세션 유지] 액세스 토큰 재발급 API",
+        description = """
+            ## [세션 유지] 액세스 토큰을 재발급 하는 API입니다.
+            리프레시 토큰을 통해 액세스 토큰을 재발급 합니다. 
+            리프레스 토큰의 만료 기간 이전인 경우에만 재발급이 가능합니다. 
+            액세스 토큰을 재발급 하는 경우, 리프레시 토큰도 재발급 됩니다. 
+            """)
+    @Parameter(name = "accessToken", description = "카카오 액세스 토큰을 입력 해 주세요. ", required = true)
     @PostMapping("/reissue")
     public ApiResponse<TokenDTO> reissueToken(@RequestHeader String refreshToken) {
-        return ApiResponse.onSuccess(SuccessStatus._CREATED, jwtTokenProvider.reissueToken(refreshToken));
+        return ApiResponse.onSuccess(SuccessStatus._CREATED, authService.reissueToken(refreshToken));
     }
+
+    @Operation(summary = "[회원 가입] 일반 회원 가입 API",
+        description = """
+            ## [회원 가입] 일반 회원 가입 API입니다.
+            회원 가입 시, 아이디(이메일)과 비밀번호를 입력하여 회원 가입을 진행합니다.
+            회원 가입에 성공하면, 액세스 토큰과 리프레시 토큰이 발급됩니다.
+            액세스 토큰은 사용자의 정보를 인증하는데 사용되며, 리프레시 토큰은 액세스 토큰이 만료된 경우, 액세스 토큰을 재발급 하는데 사용됩니다.
+            액세스 토큰이 만료된 경우, 유효한 상태의 리프레시 토큰을 통해 액세스 토큰을 재발급 받을 수 있습니다.
+            """)
+    @PostMapping("/sign-up")
+    public ApiResponse<TokenDTO> signUp() {
+        return null;
+    }
+
+    @Operation(summary = "[로그인] 일반 로그인 API",
+        description = """
+            ## [로그인] 아이디(이메일)과 비밀번호를 통해 로그인 하는 API입니다.
+            로그인에 성공하면, 액세스 토큰과 리프레시 토큰이 발급됩니다.
+            액세스 토큰은 사용자의 정보를 인증하는데 사용되며, 리프레시 토큰은 액세스 토큰이 만료된 경우, 액세스 토큰을 재발급 하는데 사용됩니다.
+            액세스 토큰이 만료된 경우, 유효한 상태의 리프레시 토큰을 통해 액세스 토큰을 재발급 받을 수 있습니다.
+            """)
+    @PostMapping("/login")
+    public ApiResponse<TokenDTO> login() {
+        return null;
+    }
+
+    @Operation(summary = "[로그아웃] 로그아웃 API",
+        description = """
+            ## [로그아웃] 로그아웃 API입니다.
+            로그아웃을 진행합니다. 
+            로그아웃 시, 사용 하던 액세스 토큰과 리프레시 토큰은 더 이상 사용이 불가능합니다. 
+            다시 서비스를 이용하기 위해서는 로그인을 다시 진행해야 합니다.
+            """)
+    @PostMapping("/logout")
+    public ApiResponse<TokenDTO> logout() {
+        return null;
+    }
+
 
 
 }

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -34,8 +34,9 @@ public class AuthController {
             액세스 토큰을 재발급 하는 경우, 리프레시 토큰도 재발급 됩니다. 
             """)
     @PostMapping("/reissue")
-    public ApiResponse<TokenDTO> reissueToken(HttpServletRequest request) {
-        return ApiResponse.onSuccess(SuccessStatus._CREATED, authService.reissueToken(request));
+    public ApiResponse<TokenDTO> reissueToken(HttpServletRequest request,
+        @RequestHeader("refreshToken") String refreshToken){
+        return ApiResponse.onSuccess(SuccessStatus._CREATED, authService.reissueToken(refreshToken));
     }
 
     @Operation(summary = "[회원 가입] 일반 회원 가입 API",

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,12 +30,12 @@ public class AuthController {
         description = """
             ## [세션 유지] 액세스 토큰을 재발급 하는 API입니다.
             리프레시 토큰을 통해 액세스 토큰을 재발급 합니다. 
-            리프레스 토큰의 만료 기간 이전인 경우에만 재발급이 가능합니다. 
+            리프레시 토큰의 만료 기간 이전인 경우에만 재발급이 가능합니다. 
             액세스 토큰을 재발급 하는 경우, 리프레시 토큰도 재발급 됩니다. 
             """)
     @PostMapping("/reissue")
-    public ApiResponse<TokenDTO> reissueToken(@RequestParam String refreshToken) {
-        return ApiResponse.onSuccess(SuccessStatus._CREATED, authService.reissueToken(refreshToken));
+    public ApiResponse<TokenDTO> reissueToken(HttpServletRequest request) {
+        return ApiResponse.onSuccess(SuccessStatus._CREATED, authService.reissueToken(request));
     }
 
     @Operation(summary = "[회원 가입] 일반 회원 가입 API",

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -2,11 +2,9 @@ package com.example.spot.web.controller;
 
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
-import com.example.spot.security.utils.JwtTokenProvider;
-import com.example.spot.service.oauth.AuthService;
+import com.example.spot.service.auth.AuthService;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth", description = "Auth API")

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -1,4 +1,4 @@
-package com.example.spot.web;
+package com.example.spot.web.controller;
 
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
@@ -9,16 +9,20 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth", description = "Auth API")
+@Slf4j
 @RestController
 @RequestMapping("/spot")
 @RequiredArgsConstructor
 public class AuthController {
+
     private final AuthService authService;
 
     @Operation(summary = "[세션 유지] 액세스 토큰 재발급 API",
@@ -28,9 +32,8 @@ public class AuthController {
             리프레스 토큰의 만료 기간 이전인 경우에만 재발급이 가능합니다. 
             액세스 토큰을 재발급 하는 경우, 리프레시 토큰도 재발급 됩니다. 
             """)
-    @Parameter(name = "accessToken", description = "카카오 액세스 토큰을 입력 해 주세요. ", required = true)
     @PostMapping("/reissue")
-    public ApiResponse<TokenDTO> reissueToken(@RequestHeader String refreshToken) {
+    public ApiResponse<TokenDTO> reissueToken(@RequestParam String refreshToken) {
         return ApiResponse.onSuccess(SuccessStatus._CREATED, authService.reissueToken(refreshToken));
     }
 

--- a/src/main/java/com/example/spot/web/controller/MemberController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberController.java
@@ -62,7 +62,7 @@ public class MemberController {
             ## localhost:8080/spot/login  
             
            생성된 회원의 액세스 토큰과 Email이 반환 됩니다. """)
-    @GetMapping("/login")
+    @GetMapping("/login/kakao")
     public void login() throws IOException {
         memberService.redirectURL();
     }

--- a/src/main/java/com/example/spot/web/controller/MemberController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberController.java
@@ -58,8 +58,8 @@ public class MemberController {
             가입 테스트를 위해 구현한 테스트 용 카카오 로그인입니다. 
             서버 파트 및 테스트를 원하는 분들은 본 API로 회원 가입 및 로그인을 진행하시면 됩니다. 
             Swagger에서 요청하는 것이 아닌, 브라우저에서 직접 요청해주세요. 
-            ## www.teamspot.site/spot/login 
-            ## localhost:8080/spot/login  
+            ## www.teamspot.site/spot/login/kakao 
+            ## localhost:8080/spot/login/kakao  
             
            생성된 회원의 액세스 토큰과 Email이 반환 됩니다. """)
     @GetMapping("/login/kakao")
@@ -73,8 +73,8 @@ public class MemberController {
             가입 테스트를 위해 구현한 테스트 용 리다이렉트 URL입니다. 
             서버 파트 및 테스트를 원하는 분들은 본 API로 회원 가입 및 로그인을 진행하시면 됩니다. 
             Swagger에서 요청하는 것이 아닌, 브라우저에서 직접 요청해주세요. 
-            ## www.teamspot.site/spot/login 
-            ## localhost:8080/spot/login  
+            ## www.teamspot.site/spot/login/kakao
+            ## localhost:8080/spot/login/kakao  
             
            생성된 회원의 액세스 토큰과 Email이 반환 됩니다. """)
     @GetMapping("/members/sign-in/kakao/redirect")

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -1,11 +1,15 @@
 package com.example.spot.web.controller;
 
 import com.example.spot.api.ApiResponse;
+import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.code.status.SuccessStatus;
+import com.example.spot.api.exception.GeneralException;
 import com.example.spot.domain.enums.StudySortBy;
 import com.example.spot.domain.enums.ThemeType;
+import com.example.spot.security.utils.SecurityUtils;
 import com.example.spot.service.study.StudyQueryService;
 import com.example.spot.validation.annotation.ExistMember;
+import com.example.spot.validation.validator.MemberValidator;
 import com.example.spot.web.dto.search.SearchRequestDTO.SearchRequestStudyDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.StudyPreviewDTO;
@@ -15,9 +19,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -350,6 +357,7 @@ public class SearchController {
         @PathVariable @ExistMember Long memberId,
         @RequestParam @Min(0) Integer page,
         @RequestParam @Min(1) Integer size) {
+        SecurityUtils.verifyUserId(memberId);
         StudyPreviewDTO studies = studyQueryService.findAppliedStudies(
             PageRequest.of(page, size), memberId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);

--- a/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
@@ -26,6 +26,7 @@ public class MemberResponseDTO {
     public static class MemberTestDTO{
         private Long memberId;
         private String email;
+        private TokenDTO tokens;
 
     }
 

--- a/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
@@ -1,6 +1,7 @@
 package com.example.spot.web.dto.member;
 
 import java.time.LocalDateTime;
+import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +14,9 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MemberSignInDTO{
-        private String accessToken;
+        private TokenDTO tokens;
         private String email;
+        private Long memberId;
     }
 
     @Builder

--- a/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
+++ b/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
@@ -56,6 +56,7 @@ public class KaKaoUser {
             .password("default")
             .phone("NONE")
             .birth(LocalDate.now())
+            .refreshToken("default")
             .personalInfo(false)
             .idInfo(false)
             .isAdmin(false)

--- a/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
+++ b/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
@@ -56,7 +56,6 @@ public class KaKaoUser {
             .password("default")
             .phone("NONE")
             .birth(LocalDate.now())
-            .refreshToken("default")
             .personalInfo(false)
             .idInfo(false)
             .isAdmin(false)

--- a/src/main/java/com/example/spot/web/dto/token/TokenResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/token/TokenResponseDTO.java
@@ -1,0 +1,20 @@
+package com.example.spot.web.dto.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TokenResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenDTO{
+        private String accessToken;
+        private String refreshToken;
+        private Long accessTokenExpiresIn;
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈 번호, #이슈 링크 https://github.com/SPOTeam/Server/issues/69

<br/>

## 🔎 작업 내용

1. JWT 기반 Refresh Token 발급
2. Refresh Token을 통한 Access Token 재발급
3.  Access Token에 담긴 회원 정보와 현재 API를 요청하는 회원 정보의 일치 여부 판단 하는 메서드 구현(권한 판단)

### 변경 사항
1. 카카오 소셜 로그인 엔드 포인트가 `/spot/login/kakao` 로 변경 되었습니다.

2. 로그인 및 테스트 회원 생성 시, 이제`refreshToken`도 발급 됩니다. `refreshToken`은 `accessToken`의 만료 시 재발급에 사용되는 토큰으로, 다른 API 사용 시에는 사용하실 필요는 없습니다. 
3.  `accessToken`이 만료 되었다면,  `refreshToken`을 통해 재발급 받아야 합니다. 재발급 시, `accessToken`만 재발급 되는 것이 아닌,  `refreshToken` 또한 재발급 되므로 기존에 사용하던  `refreshToken`은 더 이상 사용하실 수 없습니다. 
4. `spot/security/utils/SecurityUtils.java` 파일 내 권한을 판단 하는 메서드가 작성되었습니다.`accessToken`에 담긴 회원 정보와 현재 API를 요청하는 회원 정보의 일치 여부를 판단하기 원하시면, 해당 메서드를 사용하시면 됩니다. 

<br/>

## 📷 스크린샷 (선택)

<img width="1273" alt="스크린샷 2024-08-02 오후 2 03 14" src="https://github.com/user-attachments/assets/f092af5b-d561-4b2f-91ea-d26f07ec0fdc"> 
회원 가입 시
 
---
<img width="1282" alt="스크린샷 2024-08-02 오후 2 03 51" src="https://github.com/user-attachments/assets/46758dfb-dbfa-4fb2-b3fc-c34b40dd6c7f">path variable에 담긴 회원의 정보와 accessToken에 담긴 회원의 정보가 일치하지 않는 경우, (변경 사항 3번의 메서드를 통해 검증)

---
<img width="1432" alt="스크린샷 2024-08-02 오후 2 04 07" src="https://github.com/user-attachments/assets/f5fbede0-aa62-460f-99c1-6fa271322300">액세스 토큰 재발급

---
<img width="1361" alt="스크린샷 2024-08-02 오후 2 04 15" src="https://github.com/user-attachments/assets/4cb0ae8f-91f1-45b9-9a4a-aa59cf718141">유효 기간이 지났거나, 재발급 후 새로운 리프레시 토큰이 아닌 이전 리프레시 토큰을 사용한 경우
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
