### PR TITLE
[FEAT] 담당 API에 SecurityUtils 통한 사용자 인증/인가 로직 추가

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -50,6 +50,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _STUDY_APPLY_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "STUDY4010","스터디 신청이 이미 처리된 회원입니다."),
     _STUDY_OWNER_CANNOT_APPLY(HttpStatus.BAD_REQUEST, "STUDY4011", "스터디장은 스터디에 신청할 수 없습니다."),
     _STUDY_IS_FULL(HttpStatus.BAD_REQUEST, "STUDY4012", "스터디 인원이 가득 찼습니다."),
+    _ONLY_STUDY_OWNER_CAN_ACCESS_APPLICANTS(HttpStatus.FORBIDDEN, "STUDY4013", "스터디장만 신청자 목록에 접근할 수 있습니다."),
+    _ONLY_STUDY_MEMBER_CAN_ACCESS_ANNOUNCEMENT_POST(HttpStatus.FORBIDDEN, "STUDY4014", "스터디 멤버만 공지 게시글에 접근할 수 있습니다."),
+    _ONLY_STUDY_MEMBER_CAN_ACCESS_SCHEDULE(HttpStatus.FORBIDDEN, "STUDY4015", "스터디 멤버만 일정에 접근할 수 있습니다."),
+    _ONLY_STUDY_MEMBER_CAN_ACCESS_MEMBERS(HttpStatus.FORBIDDEN, "STUDY4016", "스터디 멤버만 회원 목록에 접근할 수 있습니다."),
 
     //스터디 게시글 관련 에러
     _STUDY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "스터디 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/security/utils/SecurityUtils.java
+++ b/src/main/java/com/example/spot/security/utils/SecurityUtils.java
@@ -19,10 +19,21 @@ public class SecurityUtils {
 
     // 현재 인증된 사용자의 ID와 매개변수로 전달된 ID가 일치하는지 확인
     public static void verifyUserId(Long memberId) {
+        // 관리자면, 모든 API 접근 가능
+        if (isAdmin())
+            return;
+
         Long currentUserId = getCurrentUserId();
-        if (!Objects.equals(currentUserId, memberId)) {
+
+        if (!Objects.equals(currentUserId, memberId))
             throw new GeneralException(ErrorStatus._MEMBER_NO_ACCESS);
-        }
+    }
+
+    // 현재 인증된 사용자의 역할이 ADMIN인지 확인
+    public static boolean isAdmin() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getAuthorities().stream()
+            .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"));
     }
 
 }

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
@@ -103,6 +103,9 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
     public StudyApplyResponseDTO acceptAndRejectStudyApply(Long memberId, Long studyId,
         boolean isAccept) {
 
+        if (!isOwner(SecurityUtils.getCurrentUserId(), studyId))
+            throw new GeneralException(ErrorStatus._ONLY_STUDY_OWNER_CAN_ACCESS_APPLICANTS);
+
         MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyId(memberId, studyId)
             .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_APPLICANT_NOT_FOUND));
 
@@ -1017,5 +1020,14 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
         });
     }
 
+    // 로그인 한 회원이 해당 스터디 장인지 확인
+    private boolean isOwner(Long memberId, Long studyId) {
+        return memberStudyRepository.findByMemberIdAndStudyIdAndIsOwned(memberId, studyId, true).isPresent();
+    }
+
+    // 로그인 한 회원이 해당 스터디 원인지 확인
+    private boolean isMember(Long memberId, Long studyId) {
+        return memberStudyRepository.findByMemberIdAndStudyIdAndStatus(memberId, studyId, ApplicationStatus.APPROVED).isPresent();
+    }
 
 }

--- a/src/main/java/com/example/spot/web/controller/MemberController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.example.spot.web.controller;
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
 
+import com.example.spot.security.utils.SecurityUtils;
 import com.example.spot.service.member.MemberService;
 import com.example.spot.web.dto.member.MemberResponseDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberRegionDTO;
@@ -64,6 +65,7 @@ public class MemberController {
     @PostMapping("/member/{memberId}/test/admin")
     public ApiResponse<MemberResponseDTO.MemberUpdateDTO> toAdmin(
         @ExistMember @PathVariable Long memberId){
+        SecurityUtils.verifyUserId(memberId);
         MemberUpdateDTO dto = memberService.toAdmin(memberId);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_CREATED, dto);
     }
@@ -130,6 +132,7 @@ public class MemberController {
     public ApiResponse<MemberUpdateDTO> updateThemes(
         @PathVariable @ExistMember Long memberId,
         @RequestBody @Valid MemberRequestDTO.MemberThemeDTO requestDTO){
+        SecurityUtils.verifyUserId(memberId);
         MemberUpdateDTO memberUpdateDTO = memberService.updateTheme(memberId, requestDTO);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_THEME_UPDATE, memberUpdateDTO);
     }
@@ -147,6 +150,7 @@ public class MemberController {
     public ApiResponse<MemberUpdateDTO> updateRegions(
         @PathVariable @ExistMember Long memberId,
         @RequestBody @Valid MemberRequestDTO.MemberRegionDTO requestDTO){
+        SecurityUtils.verifyUserId(memberId);
         MemberUpdateDTO memberUpdateDTO = memberService.updateRegion(memberId, requestDTO);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_REGION_UPDATE, memberUpdateDTO);
     }
@@ -163,6 +167,7 @@ public class MemberController {
     public ApiResponse<MemberUpdateDTO> updateMemberInfo(
         @PathVariable @ExistMember Long memberId,
         @RequestBody @Valid MemberInfoListDTO requestDTO){
+        SecurityUtils.verifyUserId(memberId);
         MemberUpdateDTO memberUpdateDTO = memberService.updateProfile(memberId, requestDTO);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_INFO_UPDATE, memberUpdateDTO);
     }
@@ -189,6 +194,7 @@ public class MemberController {
     public ApiResponse<MemberUpdateDTO> updateMemberStudyReason(
         @PathVariable @ExistMember Long memberId,
         @RequestBody @Valid MemberRequestDTO.MemberReasonDTO requestDTO){
+        SecurityUtils.verifyUserId(memberId);
         MemberUpdateDTO memberUpdateDTO = memberService.updateStudyReason(memberId, requestDTO);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_INFO_UPDATE, memberUpdateDTO);
     }
@@ -205,6 +211,7 @@ public class MemberController {
     @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
     public ApiResponse<MemberResponseDTO.MemberThemeDTO> getThemes(
         @PathVariable @ExistMember Long memberId){
+        SecurityUtils.verifyUserId(memberId);
         MemberResponseDTO.MemberThemeDTO memberThemeDTO = memberService.getThemes(memberId);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_THEME_UPDATE, memberThemeDTO);
     }
@@ -221,6 +228,7 @@ public class MemberController {
     @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
     public ApiResponse<MemberResponseDTO.MemberRegionDTO> getRegions(
         @PathVariable @ExistMember Long memberId){
+        SecurityUtils.verifyUserId(memberId);
         MemberRegionDTO memberRegionDTO = memberService.getRegions(memberId);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_REGION_UPDATE, memberRegionDTO);
     }
@@ -237,6 +245,7 @@ public class MemberController {
     @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
     public ApiResponse<MemberResponseDTO.MemberStudyReasonDTO> getStudyReasons(
         @PathVariable @ExistMember Long memberId){
+        SecurityUtils.verifyUserId(memberId);
         MemberStudyReasonDTO memberStudyReasonDTO = memberService.getStudyReasons(memberId);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_REGION_UPDATE, memberStudyReasonDTO);
     }

--- a/src/main/java/com/example/spot/web/controller/MemberStudyController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberStudyController.java
@@ -3,6 +3,7 @@ package com.example.spot.web.controller;
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
 import com.example.spot.domain.enums.Theme;
+import com.example.spot.security.utils.SecurityUtils;
 import com.example.spot.service.memberstudy.MemberStudyCommandService;
 import com.example.spot.service.memberstudy.MemberStudyQueryService;
 import com.example.spot.validation.annotation.*;
@@ -39,6 +40,7 @@ public class MemberStudyController {
         """)
     @DeleteMapping("/members/{memberId}/studies/{studyId}/withdrawal")
     public ApiResponse<StudyWithdrawalResponseDTO.WithdrawalDTO> withdrawFromStudy(@PathVariable Long memberId, @PathVariable Long studyId) {
+        SecurityUtils.verifyUserId(memberId);
         StudyWithdrawalResponseDTO.WithdrawalDTO withdrawalDTO = memberStudyCommandService.withdrawFromStudy(memberId, studyId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_MEMBER_DELETED, withdrawalDTO);
     }

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -46,7 +46,8 @@ public class SearchController {
         security = @SecurityRequirement(name = "accessToken"))
     @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
     public ApiResponse<StudyPreviewDTO> recommendStudiesForMain(@PathVariable @ExistMember long memberId) {
-       StudyPreviewDTO recommendStudies = studyQueryService.findRecommendStudies(memberId);
+        SecurityUtils.verifyUserId(memberId);
+        StudyPreviewDTO recommendStudies = studyQueryService.findRecommendStudies(memberId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, recommendStudies);
     }
     @Tag(name = "마이 페이지", description = "마이 페이지 API")
@@ -58,6 +59,7 @@ public class SearchController {
         security = @SecurityRequirement(name = "accessToken"))
     @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
     public ApiResponse<MyPageDTO> myPage(@PathVariable @ExistMember long memberId) {
+        SecurityUtils.verifyUserId(memberId);
         MyPageDTO myPageStudyCount = studyQueryService.getMyPageStudyCount(memberId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND,  myPageStudyCount);
     }
@@ -96,6 +98,7 @@ public class SearchController {
         @RequestParam @Min(1) Integer size,
         @RequestParam StudySortBy sortBy
     ) {
+        SecurityUtils.verifyUserId(memberId);
         StudyPreviewDTO studies = studyQueryService.findInterestStudiesByConditionsAll(PageRequest.of(page, size), memberId,
             searchRequestStudyDTO, sortBy);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
@@ -131,6 +134,7 @@ public class SearchController {
         @RequestParam @Min(1) Integer size,
         @RequestParam StudySortBy sortBy
     ) {
+        SecurityUtils.verifyUserId(memberId);
         StudyPreviewDTO studies = studyQueryService.findInterestStudiesByConditionsSpecific(PageRequest.of(page, size), memberId,
             searchRequestStudyDTO, theme, sortBy);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
@@ -171,6 +175,7 @@ public class SearchController {
         @RequestParam StudySortBy sortBy
 
     ) {
+        SecurityUtils.verifyUserId(memberId);
         StudyPreviewDTO studies = studyQueryService.findInterestRegionStudiesByConditionsAll(
             PageRequest.of(page, size), memberId, searchRequestStudyDTO, sortBy);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
@@ -206,6 +211,7 @@ public class SearchController {
         @RequestParam @Min(1) Integer size,
         @RequestParam StudySortBy sortBy
     ) {
+        SecurityUtils.verifyUserId(memberId);
         StudyPreviewDTO studies = studyQueryService.findInterestRegionStudiesByConditionsSpecific(
             PageRequest.of(page, size), memberId, searchRequestStudyDTO, regionCode, sortBy);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
@@ -214,7 +220,7 @@ public class SearchController {
     /* ----------------------------- 모집 중 스터디 조회  ------------------------------------- */
 
 
-    @Tag(name = "내 스터디 조회")
+    @Tag(name = "모집 중 스터디 조회")
     @GetMapping("/search/studies/recruiting")
     @Operation(
         summary = "[모집 중 스터디 조회] 모집 중인 스터디 조회",
@@ -261,6 +267,7 @@ public class SearchController {
     @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
     public ApiResponse<StudyPreviewDTO> likedStudies(
         @PathVariable @ExistMember long memberId) {
+        SecurityUtils.verifyUserId(memberId);
         // 메소드 구현
         StudyPreviewDTO studies = studyQueryService.findLikedStudies(memberId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
@@ -327,6 +334,7 @@ public class SearchController {
         @PathVariable @ExistMember Long memberId,
         @RequestParam @Min(0) Integer page,
         @RequestParam @Min(1) Integer size) {
+        SecurityUtils.verifyUserId(memberId);
         StudyPreviewDTO studies = studyQueryService.findOngoingStudiesByMemberId(
             PageRequest.of(page, size), memberId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
@@ -347,6 +355,7 @@ public class SearchController {
         @PathVariable @ExistMember Long memberId,
         @RequestParam @Min(0) Integer page,
         @RequestParam @Min(1) Integer size) {
+        SecurityUtils.verifyUserId(memberId);
         StudyPreviewDTO studies = studyQueryService.findMyRecruitingStudies(
             PageRequest.of(page, size), memberId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);

--- a/src/main/java/com/example/spot/web/controller/StudyController.java
+++ b/src/main/java/com/example/spot/web/controller/StudyController.java
@@ -2,6 +2,7 @@ package com.example.spot.web.controller;
 
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
+import com.example.spot.security.utils.SecurityUtils;
 import com.example.spot.service.study.StudyCommandService;
 import com.example.spot.service.study.StudyQueryService;
 import com.example.spot.validation.annotation.ExistMember;
@@ -51,6 +52,7 @@ public class StudyController {
     public ApiResponse<StudyJoinResponseDTO.JoinDTO> applyToStudy(
             @PathVariable @ExistMember Long memberId, @PathVariable @ExistStudy Long studyId,
             @RequestBody @Valid StudyJoinRequestDTO.StudyJoinDTO studyJoinRequestDTO) {
+        SecurityUtils.verifyUserId(memberId);
         StudyJoinResponseDTO.JoinDTO studyJoinResponseDTO = studyCommandService.applyToStudy(memberId, studyId, studyJoinRequestDTO);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_APPLY_COMPLETED, studyJoinResponseDTO);
     }
@@ -63,6 +65,7 @@ public class StudyController {
     public ApiResponse<StudyRegisterResponseDTO.RegisterDTO> registerStudy(
             @PathVariable @ExistMember Long memberId,
             @RequestBody @Valid StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO) {
+        SecurityUtils.verifyUserId(memberId);
         StudyRegisterResponseDTO.RegisterDTO studyRegisterResponseDTO = studyCommandService.registerStudy(memberId, studyRegisterRequestDTO);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_CREATED, studyRegisterResponseDTO);
     }
@@ -81,6 +84,7 @@ public class StudyController {
     public ApiResponse<StudyLikeResponseDTO> likeStudy(
         @PathVariable("studyId") @ExistStudy Long studyId,
         @PathVariable("memberId") @ExistMember Long memberId) {
+        SecurityUtils.verifyUserId(memberId);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_LIKED, studyCommandService.likeStudy(memberId, studyId));
     }
 }

--- a/src/main/java/com/example/spot/web/dto/study/request/StudyRegisterRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/request/StudyRegisterRequestDTO.java
@@ -36,7 +36,6 @@ public class StudyRegisterRequestDTO {
 
         private List<String> regions;
 
-        @IntSize(min = 2)
         private Long maxPeople;
 
         private Gender gender;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈 번호, #이슈 링크 https://github.com/SPOTeam/Server/issues/94

<br/>

## 🔎 작업 내용

1. 회원 관련 API 적용
2. 스터디 조회 API 적용
3. 스터디 관련 기능 API 적용


<br/>

