### PR TITLE
게시판 댓글 관련 API 구현

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -122,6 +122,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _POST_ALREADY_LIKED(HttpStatus.BAD_REQUEST, "POST5008", "이미 좋아요한 게시글입니다."),
     _POST_NOT_LIKED(HttpStatus.BAD_REQUEST, "POST5009", "좋아요하지 않은 게시글입니다."),
     _POST_ID_NULL(HttpStatus.BAD_REQUEST, "POST5010", "게시글 아이디가 입력되지 않았습니다."),
+    _POST_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POST5010", "게시글 댓글을 찾을 수 없습니다."),
+    _POST_COMMENT_ALREADY_LIKED(HttpStatus.BAD_REQUEST, "POST5011", "이미 좋아요한 댓글입니다."),
+    _POST_COMMENT_NOT_LIKED(HttpStatus.BAD_REQUEST, "POST5012", "좋아요하지 않은 게시글 댓글입니다."),
+    _POST_COMMENT_ALREADY_DISLIKED(HttpStatus.BAD_REQUEST, "POST5013", "이미 싫어요한 댓글입니다."),
+    _POST_COMMENT_NOT_DISLIKED(HttpStatus.BAD_REQUEST, "POST5014", "싫어요하지 않은 게시글 댓글입니다."),
 
     // 스터디 투표 관련 에러
     _STUDY_VOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "VOTE4001", "스터디 투표를 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/domain/LikedPostComment.java
+++ b/src/main/java/com/example/spot/domain/LikedPostComment.java
@@ -15,7 +15,7 @@ public class LikedPostComment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private boolean is_liked; //좋아요:1, 싫어요:0
+    private boolean isLiked; //좋아요:1, 싫어요:0
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_comment_id")
@@ -24,5 +24,11 @@ public class LikedPostComment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public LikedPostComment(PostComment postComment, Member member, boolean isLiked) {
+        this.postComment = postComment;
+        this.member = member;
+        this.isLiked = isLiked;
+    }
 
 }

--- a/src/main/java/com/example/spot/domain/PostComment.java
+++ b/src/main/java/com/example/spot/domain/PostComment.java
@@ -39,7 +39,6 @@ public class PostComment extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-
     //대댓글
     @ManyToOne
     @JoinColumn(name = "parent_id")

--- a/src/main/java/com/example/spot/repository/LikedPostCommentRepository.java
+++ b/src/main/java/com/example/spot/repository/LikedPostCommentRepository.java
@@ -1,0 +1,14 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.LikedPostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikedPostCommentRepository extends JpaRepository<LikedPostComment, Long> {
+    Optional<LikedPostComment> findByMemberIdAndPostCommentIdAndIsLikedTrue(Long memberId, Long postCommentId);
+    Optional<LikedPostComment> findByMemberIdAndPostCommentIdAndIsLikedFalse(Long memberId, Long postCommentId);
+    long countByPostCommentIdAndIsLikedTrue(Long postCommentId);
+    long countByPostCommentIdAndIsLikedFalse(Long postCommentId);
+
+}

--- a/src/main/java/com/example/spot/repository/PostCommentRepository.java
+++ b/src/main/java/com/example/spot/repository/PostCommentRepository.java
@@ -1,0 +1,9 @@
+package com.example.spot.repository;
+
+import com.example.spot.domain.PostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
+    List<PostComment> findByPostId(Long postId);
+}

--- a/src/main/java/com/example/spot/repository/querydsl/impl/PostRepositoryImpl.java
+++ b/src/main/java/com/example/spot/repository/querydsl/impl/PostRepositoryImpl.java
@@ -63,12 +63,10 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .where(post.createdAt.after(twoHoursAgo))
                 //.groupBy(post)
                 .orderBy(
-                        post.hitNum.add(post.likedPostList.size()).add(post.postCommentList.size()).desc()
-//                        post.hitNum.desc(),
-//                        post.likedPostList.size().desc(),
-//                        post.postCommentList.size().desc()
-//                        like.count().desc(),
-//                        comment.count().desc()
+                        post.hitNum.add(post.likedPostList.size()).add(post.postCommentList.size()).desc(),
+                        post.hitNum.desc(),
+                        post.likedPostList.size().desc(),
+                        post.postCommentList.size().desc()
                 )
                 .limit(5)
                 .fetch();

--- a/src/main/java/com/example/spot/service/post/LikedPostCommentQueryService.java
+++ b/src/main/java/com/example/spot/service/post/LikedPostCommentQueryService.java
@@ -1,0 +1,5 @@
+package com.example.spot.service.post;
+
+public interface LikedPostCommentQueryService {
+    long countByPostCommentIdAndIsLikedTrue(Long postCommentId);
+}

--- a/src/main/java/com/example/spot/service/post/LikedPostCommentQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/post/LikedPostCommentQueryServiceImpl.java
@@ -1,0 +1,19 @@
+package com.example.spot.service.post;
+
+import com.example.spot.repository.LikedPostCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikedPostCommentQueryServiceImpl implements LikedPostCommentQueryService{
+    private final LikedPostCommentRepository likedPostCommentRepository;
+
+    @Override
+    public long countByPostCommentIdAndIsLikedTrue(Long postCommentId){
+        return likedPostCommentRepository.countByPostCommentIdAndIsLikedTrue(postCommentId);
+    }
+
+}

--- a/src/main/java/com/example/spot/service/post/PostCommandService.java
+++ b/src/main/java/com/example/spot/service/post/PostCommandService.java
@@ -6,14 +6,34 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface PostCommandService {
 
+    //게시글 생성
     PostCreateResponse createPost(Long memberId, PostCreateRequest postCreateRequest);
 
+    //게시글 삭제
     void deletePost(Long memberId, Long postId);
 
+    //게시글 수정
     PostCreateResponse updatePost(Long memberId, Long postId, PostUpdateRequest postUpdateRequest);
 
+    //게시글 좋아요
     PostLikeResponse likePost(Long postId, Long memberId);
 
+    //게시글 좋아요 취소
     PostLikeResponse cancelPostLike(Long postId, Long memberId);
+
+    //게시글 댓글 생성
+    CommentCreateResponse createComment(Long postId, Long memberId, CommentCreateRequest request);
+
+    //게시글 댓글 좋아요
+    CommentLikeResponse likeComment(Long CommentId, Long memberId);
+
+    //게시글 댓글 좋아요 취소
+    CommentLikeResponse cancelCommentLike(Long CommentId, Long memberId);
+
+    //게시글 댓글 싫어요
+    CommentLikeResponse dislikeComment(Long CommentId, Long memberId);
+
+    //게시글 댓글 싫어요 취소
+    CommentLikeResponse cancelCommentDislike(Long CommentId, Long memberId);
 
 }

--- a/src/main/java/com/example/spot/service/post/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/post/PostCommandServiceImpl.java
@@ -3,17 +3,15 @@ package com.example.spot.service.post;
 import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.handler.MemberHandler;
 import com.example.spot.api.exception.handler.PostHandler;
-import com.example.spot.domain.LikedPost;
-import com.example.spot.domain.Member;
-import com.example.spot.domain.Post;
+import com.example.spot.domain.*;
 import com.example.spot.domain.enums.Board;
-import com.example.spot.repository.LikedPostRepository;
-import com.example.spot.repository.MemberRepository;
-import com.example.spot.repository.PostRepository;
+import com.example.spot.repository.*;
 import com.example.spot.web.dto.post.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,8 +20,12 @@ public class PostCommandServiceImpl implements PostCommandService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final LikedPostRepository likedPostRepository;
+    private final PostCommentRepository postCommentRepository;
+    private final LikedPostCommentRepository likedPostCommentRepository;
 
     private final LikedPostQueryService likedPostQueryService;
+    private final LikedPostCommentQueryService likedPostCommentQueryService;
+
 
     @Transactional
     @Override
@@ -159,6 +161,154 @@ public class PostCommandServiceImpl implements PostCommandService {
                 .postId(post.getId())
                 .likeCount(likeCount)
                 .build();
+    }
+
+    @Transactional
+    @Override
+    public CommentCreateResponse createComment(Long postId, Long memberId, CommentCreateRequest request) {
+        // 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus._POST_NOT_FOUND));
+
+        // 회원 정보 가져오기
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        //부모 댓글아이디
+        Long parentCommentId = request.getParentCommentId();
+        Optional<PostComment> optionalParentComment = postCommentRepository.findById(parentCommentId);
+
+        if (optionalParentComment.isPresent()) {
+            PostComment parentComment = optionalParentComment.get();
+            // 자식댓글 생성
+            PostComment comment = PostComment.builder()
+                    .content(request.getContent())
+                    .isAnonymous(request.isAnonymous())
+                    .post(post)
+                    .parentComment(parentComment)
+                    .member(member)
+                    .build();
+
+            postCommentRepository.saveAndFlush(comment);
+            return CommentCreateResponse.toDTOwithParent(comment, parentComment.getId());
+
+        } else {
+            // 부모댓글 생성
+            PostComment comment = PostComment.builder()
+                    .content(request.getContent())
+                    .isAnonymous(request.isAnonymous())
+                    .post(post)
+                    .member(member)
+                    .build();
+
+            postCommentRepository.saveAndFlush(comment);
+            return CommentCreateResponse.toDTO(comment);
+        }
+    }
+
+
+    //게시글 댓글 좋아요
+    @Transactional
+    @Override
+    public CommentLikeResponse likeComment(Long commentId, Long memberId) {
+        //댓글 조회하기
+        PostComment comment = postCommentRepository.findById(commentId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus._POST_COMMENT_NOT_FOUND));
+
+        //회원 정보 가져오기
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        //좋아요 여부 확인
+        if (likedPostCommentRepository.findByMemberIdAndPostCommentIdAndIsLikedTrue(memberId, commentId).isPresent()) {
+            throw new PostHandler(ErrorStatus._POST_COMMENT_ALREADY_LIKED);
+        }
+
+        LikedPostComment likedPostComment = new LikedPostComment(comment, member, true);
+        likedPostCommentRepository.saveAndFlush(likedPostComment);
+
+        long likeCount = likedPostCommentQueryService.countByPostCommentIdAndIsLikedTrue(commentId);
+
+        long disLikeCount = likedPostCommentRepository.countByPostCommentIdAndIsLikedFalse(commentId);
+
+        return CommentLikeResponse.toDTO(comment.getId(), likeCount, disLikeCount);
+    }
+
+    //게시글 댓글 좋아요 취소
+    @Transactional
+    @Override
+    public CommentLikeResponse cancelCommentLike(Long commentId, Long memberId) {
+        //댓글 조회하기
+        PostComment comment = postCommentRepository.findById(commentId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus._POST_COMMENT_NOT_FOUND));
+
+        //회원 정보 가져오기
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        //좋아요 여부 확인
+        LikedPostComment likedPostComment = likedPostCommentRepository.findByMemberIdAndPostCommentIdAndIsLikedTrue(memberId, commentId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus._POST_COMMENT_NOT_LIKED));
+
+        likedPostCommentRepository.delete(likedPostComment);
+
+        long likeCount = likedPostCommentQueryService.countByPostCommentIdAndIsLikedTrue(commentId);
+
+        long disLikeCount = likedPostCommentRepository.countByPostCommentIdAndIsLikedFalse(commentId);
+
+        return CommentLikeResponse.toDTO(comment.getId(), likeCount, disLikeCount);
+    }
+
+    //게시글 댓글 싫어요
+    @Transactional
+    @Override
+    public CommentLikeResponse dislikeComment(Long commentId, Long memberId) {
+        //댓글 조회
+        PostComment comment = postCommentRepository.findById(commentId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus._POST_COMMENT_NOT_FOUND));
+
+        //회원 정보
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        //싫어요 여부
+        if (likedPostCommentRepository.findByMemberIdAndPostCommentIdAndIsLikedFalse(memberId, commentId).isPresent()) {
+            throw new PostHandler(ErrorStatus._POST_COMMENT_ALREADY_DISLIKED);
+        }
+
+        LikedPostComment dislikedPostComment = new LikedPostComment(comment, member, false);
+        likedPostCommentRepository.saveAndFlush(dislikedPostComment);
+
+        long likeCount = likedPostCommentQueryService.countByPostCommentIdAndIsLikedTrue(commentId);
+
+        long disLikeCount = likedPostCommentRepository.countByPostCommentIdAndIsLikedFalse(commentId);
+
+        return CommentLikeResponse.toDTO(comment.getId(), likeCount, disLikeCount);
+    }
+
+    //게시글 댓글 싫어요 취소
+    @Transactional
+    @Override
+    public CommentLikeResponse cancelCommentDislike(Long commentId, Long memberId) {
+        //댓글 조회
+        PostComment comment = postCommentRepository.findById(commentId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus._POST_COMMENT_NOT_FOUND));
+
+        //회원 정보
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+        //싫어요 여부
+        LikedPostComment dislikedPostComment = likedPostCommentRepository.findByMemberIdAndPostCommentIdAndIsLikedFalse(memberId, commentId)
+                .orElseThrow(() -> new PostHandler(ErrorStatus._POST_COMMENT_NOT_DISLIKED));
+
+        likedPostCommentRepository.delete(dislikedPostComment);
+
+        long likeCount = likedPostCommentQueryService.countByPostCommentIdAndIsLikedTrue(commentId);
+
+        long disLikeCount = likedPostCommentRepository.countByPostCommentIdAndIsLikedFalse(commentId);
+
+        return CommentLikeResponse.toDTO(comment.getId(), likeCount, disLikeCount);
     }
 
 

--- a/src/main/java/com/example/spot/service/post/PostQueryService.java
+++ b/src/main/java/com/example/spot/service/post/PostQueryService.java
@@ -14,4 +14,6 @@ public interface PostQueryService {
 
     PostAnnouncementResponse getPostAnnouncements();
 
+    CommentResponse getCommentsByPostId(Long postId);
+
 }

--- a/src/main/java/com/example/spot/web/controller/PostController.java
+++ b/src/main/java/com/example/spot/web/controller/PostController.java
@@ -130,19 +130,6 @@ public class PostController {
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 
-    @Tag(name = "게시판 - 댓글", description = "댓글 관련 API")
-    @Operation(summary = "[게시판] 댓글 조회 API", description = "댓글 ID를 받아 댓글을 조회합니다.")
-    @GetMapping("/comments/{commentId}")
-    public void getComment(
-            @Parameter(
-                    description = "조회할 댓글의 ID입니다.",
-                    schema = @Schema(type = "integer", format = "int64")
-            )
-            @PathVariable Long commentId
-    ) {
-        //메서드
-    }
-
     @Tag(name = "게시판", description = "게시판 관련 API")
     @Operation(
             summary = "[게시판] 게시글 수정 API",
@@ -203,5 +190,68 @@ public class PostController {
         return ApiResponse.onSuccess(SuccessStatus._NO_CONTENT, response);
     }
 
+
+    //댓글
+    @Operation(summary = "게시글 댓글 생성 API", description = "게시글 Id와 회원 Id를 받아 댓글을 생성합니다.")
+    @PostMapping("/{postId}/{memberId}/comments")
+    public ApiResponse<CommentCreateResponse> createComment(
+            @PathVariable Long postId,
+            @PathVariable Long memberId,
+            @RequestBody CommentCreateRequest request) {
+        CommentCreateResponse response = postCommandService.createComment(postId, memberId, request);
+        return ApiResponse.onSuccess(SuccessStatus._CREATED, response);
+    }
+
+    @Tag(name = "게시판 - 댓글", description = "댓글 관련 API")
+    @Operation(summary = "!테스트용! [게시판] 댓글 조회 API", description = "게시글 ID를 받아 댓글을 조회합니다. 댓글 조회는 이미 게시글 단건 조회에 포함되어 있습니다.")
+    @GetMapping("/{postId}/{commentId}")
+    public ApiResponse<CommentResponse> getComment(
+            @Parameter(
+                    description = "조회할 댓글의 ID입니다.",
+                    schema = @Schema(type = "integer", format = "int64")
+            )
+            @PathVariable Long postId
+    ) {
+        CommentResponse response = postQueryService.getCommentsByPostId(postId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    //게시글 댓글 좋아요
+    @Operation(summary = "게시글 댓글 좋아요 API", description = "댓글 ID와 회원 ID를 받아 댓글에 좋아요를 추가합니다.")
+    @PostMapping("/comments/{commentId}/{memberId}/like")
+    public ApiResponse<CommentLikeResponse> likeComment(
+            @PathVariable Long commentId,
+            @PathVariable Long memberId) {
+        CommentLikeResponse response = postCommandService.likeComment(commentId, memberId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    @Operation(summary = "게시글 댓글 좋아요 취소 API", description = "댓글 ID와 회원 ID를 받아 댓글에 좋아요를 취소합니다.")
+    @DeleteMapping("/comments/{commentId}/{memberId}/like")
+    public ApiResponse<CommentLikeResponse> cancelCommentLike(
+            @PathVariable Long commentId,
+            @PathVariable Long memberId) {
+        CommentLikeResponse response = postCommandService.cancelCommentLike(commentId, memberId);
+        return ApiResponse.onSuccess(SuccessStatus._NO_CONTENT, response);
+    }
+
+    //게시글 댓글 싫어요
+    @Operation(summary = "게시글 댓글 싫어요 API", description = "댓글 ID와 회원 ID를 받아 댓글에 싫어요를 추가합니다.")
+    @PostMapping("/comments/{commentId}/{memberId}/dislike")
+    public ApiResponse<CommentLikeResponse> dislikeComment(
+            @PathVariable Long commentId,
+            @PathVariable Long memberId) {
+        CommentLikeResponse response = postCommandService.dislikeComment(commentId, memberId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    @Operation(summary = "게시글 댓글 싫어요 취소 API", description = "댓글 ID와 회원 ID를 받아 댓글에 싫어요를 취소합니다.")
+    @DeleteMapping("/comments/{commentId}/{memberId}/dislike")
+    public ApiResponse<CommentLikeResponse> cancelCommentDislike(
+            @PathVariable Long commentId,
+            @PathVariable Long memberId) {
+        CommentLikeResponse response = postCommandService.cancelCommentDislike(commentId, memberId);
+        return ApiResponse.onSuccess(SuccessStatus._NO_CONTENT, response);
+    }
 
 }

--- a/src/main/java/com/example/spot/web/dto/post/CommentCreateRequest.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentCreateRequest.java
@@ -1,0 +1,24 @@
+package com.example.spot.web.dto.post;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreateRequest {
+    @Schema(description = "댓글 내용입니다.",
+            format = "string")
+    private String content;
+
+    @Schema(description = "익명 여부", example = "false")
+    private boolean isAnonymous;
+
+    @Schema(
+            description = "부모 댓글 ID (대댓글의 경우)",
+            example = "1"
+    )
+    private Long parentCommentId;
+}

--- a/src/main/java/com/example/spot/web/dto/post/CommentCreateResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentCreateResponse.java
@@ -1,0 +1,42 @@
+package com.example.spot.web.dto.post;
+
+import com.example.spot.domain.PostComment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class CommentCreateResponse {
+    @Schema(description = "댓글 ID입니다.", example = "1")
+    private Long id;
+
+    @Schema(description = "부모 댓글 ID (대댓글의 경우)", example = "1")
+    private Long parentCommentId;
+
+    @Schema(description = "댓글 내용입니다.", example = "댓글 내용")
+    private String content;
+
+    @Schema(description = "작성자 이름입니다.", example = "작성자")
+    private String writer;
+
+    public static CommentCreateResponse toDTO(PostComment comment) {
+        return CommentCreateResponse.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .writer(comment.isAnonymous() ? "익명" : comment.getMember().getName())
+                .build();
+    }
+
+    public static CommentCreateResponse toDTOwithParent(PostComment comment, Long parentCommentId) {
+        return CommentCreateResponse.builder()
+                .id(comment.getId())
+                .parentCommentId(parentCommentId)
+                .content(comment.getContent())
+                .writer(comment.isAnonymous() ? "익명" : comment.getMember().getName())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
@@ -1,0 +1,80 @@
+package com.example.spot.web.dto.post;
+
+import com.example.spot.domain.PostComment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentDetailResponse {
+    @Schema(
+            description = "댓글 ID",
+            example = "101"
+    )
+    private Long commentId;
+
+    @Schema(
+            description = "댓글 내용",
+            example = "댓글 내용 예시"
+    )
+    private String commentContent;
+
+    @Schema(
+            description = "부모 댓글 ID (대댓글의 경우)",
+            example = "1"
+    )
+    private Long parentCommentId;
+
+    @Schema(
+            description = "댓글 작성자",
+            example = "댓글 작성자 예시"
+    )
+    private String writer;
+
+    @Schema(
+            description = "작성 시간입니다.",
+            type = "string",
+            format = "date-time",
+            example = "2024-07-19T10:15:30"
+    )
+    private String writtenTime;
+
+    @Schema(
+            description = "좋아요 수입니다.",
+            format = "long"
+    )
+    private long likeCount;
+
+//    @Schema(
+//            description = "싫어요 수입니다.",
+//            format = "int"
+//    )
+//    private int disLikeCount;
+
+    public static CommentDetailResponse toDTO(PostComment comment, long likeCount) {
+        // 작성자가 익명인지 확인하여 작성자 이름 설정
+        String writerName = judgeAnonymous(comment.isAnonymous(), comment.getMember().getName());
+
+        return CommentDetailResponse.builder()
+                .commentId(comment.getId())
+                .commentContent(comment.getContent())
+                .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
+                .writer(writerName)
+                .writtenTime(comment.getCreatedAt().toString())
+                .likeCount(likeCount)
+                //.disLikeCount(comment.getDisLikeNum())
+                .build();
+    }
+    public static String judgeAnonymous(Boolean isAnonymous, String writer) {
+
+        if (isAnonymous) {
+            return "익명";
+        }
+
+        return writer;
+    }
+}

--- a/src/main/java/com/example/spot/web/dto/post/CommentLikeResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentLikeResponse.java
@@ -1,0 +1,40 @@
+package com.example.spot.web.dto.post;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentLikeResponse {
+
+    @Schema(
+            description = "댓글 ID",
+            example = "1"
+    )
+    private Long commentId;
+
+    @Schema(
+            description = "좋아요 수", example = "10"
+    )
+
+    private long likeCount;
+
+    @Schema(
+            description = "싫어요 수", example = "1"
+    )
+
+    private long disLikeCount;
+
+    public static CommentLikeResponse toDTO(Long commentId, long likeCount, long disLikeCount) {
+        return CommentLikeResponse.builder()
+                .commentId(commentId)
+                .likeCount(likeCount)
+                .disLikeCount(disLikeCount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/spot/web/dto/post/CommentResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentResponse.java
@@ -1,82 +1,19 @@
 package com.example.spot.web.dto.post;
 
-import com.example.spot.domain.PostComment;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+
 
 @Builder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentResponse {
 
-    @Schema(
-            description = "댓글 ID",
-            example = "101"
-    )
-    private Long commentId;
+    private List<CommentDetailResponse> comments;
 
-    @Schema(
-            description = "댓글 내용",
-            example = "댓글 내용 예시"
-    )
-    private String commentContent;
-
-    @Schema(
-            description = "부모 댓글 ID (대댓글의 경우)",
-            example = "1"
-    )
-    private Long parentId;
-
-    @Schema(
-            description = "댓글 작성자",
-            example = "댓글 작성자 예시"
-    )
-    private String writer;
-
-    @Schema(
-            description = "작성 시간입니다.",
-            type = "string",
-            format = "date-time",
-            example = "2024-07-19T10:15:30"
-    )
-    private String writtenTime;
-
-    @Schema(
-            description = "좋아요 수입니다.",
-            format = "int"
-    )
-    private int likeCount;
-
-    @Schema(
-            description = "싫어요 수입니다.",
-            format = "int"
-    )
-    private int disLikeCount;
-
-    public static CommentResponse toDTO(PostComment comment) {
-        // 작성자가 익명인지 확인하여 작성자 이름 설정
-        String writerName = judgeAnonymous(comment.isAnonymous(), comment.getMember().getName());
-
-        return CommentResponse.builder()
-                .commentId(comment.getId())
-                .commentContent(comment.getContent())
-                .parentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
-                .writer(writerName)
-                .writtenTime(comment.getCreatedAt().toString())
-                .likeCount(comment.getLikeNum())
-                .disLikeCount(comment.getDisLikeNum())
-                .build();
-    }
-    public static String judgeAnonymous(Boolean isAnonymous, String writer) {
-
-        if (isAnonymous) {
-            return "익명";
-        }
-
-        return writer;
-    }
 
 }

--- a/src/main/java/com/example/spot/web/dto/post/PostPagingDetailResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostPagingDetailResponse.java
@@ -77,7 +77,7 @@ public class PostPagingDetailResponse {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .likeCount(likeCount)
-                .commentCount(post.getCommentNum())
+                .commentCount(post.getPostCommentList().size())
                 .viewCount(post.getHitNum())
                 .build();
     }

--- a/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Builder
 @Getter
@@ -74,7 +73,7 @@ public class PostSingleResponse {
             description = "댓글 리스트입니다.",
             format = "array"
     )
-    private List<CommentResponse> commentResponses;
+    private CommentResponse commentResponses;
 
     @Schema(
             description = "신고 여부입니다.",
@@ -94,7 +93,7 @@ public class PostSingleResponse {
         return writer;
     }
 
-    public static PostSingleResponse toDTO(Post post, long likeCount) {
+    public static PostSingleResponse toDTO(Post post, long likeCount, CommentResponse commentResponse) {
         // 작성자가 익명인지 확인하여 작성자 이름 설정
         String writerName = judgeAnonymous(post.isAnonymous(), post.getMember().getName());
 
@@ -106,9 +105,9 @@ public class PostSingleResponse {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .likeCount(likeCount)
-                .commentCount(post.getPostCommentList().size())
+                .commentCount(commentResponse.getComments().size())
                 .viewCount(post.getHitNum())
-                .commentResponses(post.getPostCommentList().stream().map(CommentResponse::toDTO).toList())
+                .commentResponses(commentResponse)
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #86 

<br/>

## 🔎 작업 내용

1. 댓글 등록 API 구현
2. 전체 댓글 조회 API 구현
3. 댓글 좋아요 생성/삭제 API 구현
4. 댓글 싫어요 생성/삭제 API 구현


<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 댓글 조회 게시글 단건 조회시 함께 조회되도록 하였고 테스트용으로 댓글 조회 API 추가해 두긴 했습니다~ 코드 확인 부탁드립니다!!
