### PR TITLE
[modify] 내 스터디 게시글 조회 기능 수정

### DIFF
--- a/src/main/java/com/example/spot/repository/StudyLikedPostRepository.java
+++ b/src/main/java/com/example/spot/repository/StudyLikedPostRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface StudyLikedPostRepository extends JpaRepository<StudyLikedPost, Long> {
 
     Optional<StudyLikedPost> findByMemberIdAndStudyPostId(Long memberId, Long postId);
+
+    boolean existsByMemberIdAndStudyPostId(Long memberId, Long id);
 }

--- a/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostCommentResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostCommentResponseDTO.java
@@ -1,6 +1,7 @@
 package com.example.spot.web.dto.memberstudy.response;
 
 import com.example.spot.domain.Member;
+import com.example.spot.domain.mapping.StudyLikedComment;
 import com.example.spot.domain.study.StudyPostComment;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -93,11 +94,11 @@ public class StudyPostCommentResponseDTO {
         private final Long postId;
         private final List<CommentReplyDTO> comments;
 
-        public static CommentReplyListDTO toDTO(Long postId, List<StudyPostComment> comments, String defaultImage) {
+        public static CommentReplyListDTO toDTO(Long postId, List<StudyPostComment> comments, Member member, String defaultImage) {
             return CommentReplyListDTO.builder()
                     .postId(postId)
                     .comments(comments.stream()
-                            .map(comment -> CommentReplyDTO.toDTO(comment, defaultImage))
+                            .map(comment -> CommentReplyDTO.toDTO(comment, member, defaultImage))
                             .toList())
                     .build();
         }
@@ -114,9 +115,10 @@ public class StudyPostCommentResponseDTO {
         private final Integer likeCount;
         private final Integer dislikeCount;
         private final Boolean isDeleted;
+        private final String isLiked;
         private final List<CommentReplyDTO> applies;
 
-        public static CommentReplyDTO toDTO(StudyPostComment comment, String defaultImage) {
+        public static CommentReplyDTO toDTO(StudyPostComment comment, Member member, String defaultImage) {
 
             String anonymity = "익명" + comment.getAnonymousNum();
             return CommentReplyDTO.builder()
@@ -126,11 +128,27 @@ public class StudyPostCommentResponseDTO {
                     .likeCount(comment.getLikeCount())
                     .dislikeCount(comment.getDislikeCount())
                     .isDeleted(comment.getIsDeleted())
+                    .isLiked(getIsLiked(comment, member))
                     .applies(comment.getChildrenComment().stream()
                             .sorted(Comparator.comparing(StudyPostComment::getCreatedAt))
-                            .map(child -> CommentReplyDTO.toDTO(child, defaultImage))
+                            .map(child -> CommentReplyDTO.toDTO(child, member, defaultImage))
                             .toList())
                     .build();
+        }
+
+        private static String getIsLiked(StudyPostComment comment, Member member) {
+            String isLiked = "NONE";
+            for (StudyLikedComment likedComment : comment.getLikedComments()) {
+                if (likedComment.getMember().equals(member)) {
+                    if (likedComment.getIsLiked()) {
+                        isLiked = "LIKED";
+                    } else {
+                        isLiked = "DISLIKED";
+                    }
+                    break;
+                }
+            }
+            return isLiked;
         }
     }
 }

--- a/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostResDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostResDTO.java
@@ -64,8 +64,9 @@ public class StudyPostResDTO {
         private final Integer likeNum;
         private final Integer hitNum;
         private final Integer commentNum;
+        private final Boolean isLiked;
 
-        public static PostDTO toDTO(StudyPost studyPost) {
+        public static PostDTO toDTO(StudyPost studyPost, boolean isLiked) {
             return PostDTO.builder()
                     .postId(studyPost.getId())
                     .title(studyPost.getTitle())
@@ -76,6 +77,7 @@ public class StudyPostResDTO {
                     .likeNum(studyPost.getLikeNum())
                     .hitNum(studyPost.getHitNum())
                     .commentNum(studyPost.getCommentNum())
+                    .isLiked(isLiked)
                     .build();
         }
     }
@@ -95,9 +97,10 @@ public class StudyPostResDTO {
         private final Integer likeNum;
         private final Integer hitNum;
         private final Integer commentNum;
+        private final Boolean isLiked;
         private final List<ImageDTO> studyPostImages;
 
-        public static PostDetailDTO toDTO(StudyPost studyPost) {
+        public static PostDetailDTO toDTO(StudyPost studyPost, boolean isLiked) {
             return PostDetailDTO.builder()
                     .memberId(studyPost.getMember().getId())
                     .postId(studyPost.getId())
@@ -109,6 +112,7 @@ public class StudyPostResDTO {
                     .likeNum(studyPost.getLikeNum())
                     .hitNum(studyPost.getHitNum())
                     .commentNum(studyPost.getCommentNum())
+                    .isLiked(isLiked)
                     .studyPostImages(studyPost.getImages().stream()
                             .map(ImageDTO::toDTO)
                             .toList())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 

- #132 

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.

- 게시글과 댓글을 조회할 때 로그인한 회원의 좋아요/싫어요 여부를 확인할 수 있도록 수정하였습니다.

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 

<img width="1440" alt="스크린샷 2024-08-17 오후 3 10 58" src="https://github.com/user-attachments/assets/e83e66f6-7268-491c-a8a3-c659dced887f">

<img width="1440" alt="스크린샷 2024-08-17 오후 3 11 20" src="https://github.com/user-attachments/assets/7a21515b-dd79-4e77-bc85-69d2a25c33f6">


<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
