### PR TITLE
[FIX] memberCount 및 isLike 조회 시 반영 안되는 오류 수정

### DIFF
--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class StudyCommandServiceImpl implements StudyCommandService {
 

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -324,7 +324,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
 
         long totalElements = studyRepository.countStudyByStudyTheme(studyThemes, sortBy);
-        return getDTOs(studies, pageable, totalElements, null);
+        return getDTOs(studies, pageable, totalElements, SecurityUtils.getCurrentUserId());
     }
 
     @Override

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -30,6 +30,7 @@ import com.example.spot.repository.StudyPostRepository;
 import com.example.spot.repository.StudyRepository;
 import com.example.spot.repository.StudyThemeRepository;
 import com.example.spot.repository.ThemeRepository;
+import com.example.spot.security.utils.SecurityUtils;
 import com.example.spot.web.dto.search.SearchRequestDTO.SearchRequestStudyDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
@@ -88,8 +89,10 @@ public class StudyQueryServiceImpl implements StudyQueryService {
             throw new StudyHandler(ErrorStatus._STUDY_OWNER_NOT_FOUND);
         }
 
-        Member owner = memberStudyList.get(0).getMember();
-        return StudyInfoResponseDTO.StudyInfoDTO.toDTO(study, owner);
+        Member member = memberRepository.findById(SecurityUtils.getCurrentUserId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+        return StudyInfoResponseDTO.StudyInfoDTO.toDTO(study, member);
     }
 
     @Override
@@ -278,7 +281,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
 
 
-        return getDTOs(studies, pageable, totalElements, null);
+        return getDTOs(studies, pageable, totalElements, SecurityUtils.getCurrentUserId());
     }
 
     @Override
@@ -304,7 +307,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
             throw new StudyHandler(ErrorStatus._STUDY_IS_NOT_MATCH);
 
         long totalElements = studyRepository.countAllByTitleContaining(keyword, sortBy);
-        return getDTOs(studies, pageable, totalElements, null);
+        return getDTOs(studies, pageable, totalElements, SecurityUtils.getCurrentUserId());
     }
 
     @Override

--- a/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
@@ -2,6 +2,7 @@ package com.example.spot.web.dto.search;
 
 import com.example.spot.domain.Region;
 import com.example.spot.domain.Theme;
+import com.example.spot.domain.enums.ApplicationStatus;
 import com.example.spot.domain.enums.StudyState;
 import com.example.spot.domain.enums.ThemeType;
 import com.example.spot.domain.mapping.PreferredStudy;
@@ -73,7 +74,10 @@ public class SearchResponseDTO {
             this.title = study.getTitle();
             this.introduction = study.getIntroduction();
             this.goal = study.getGoal();
-            this.memberCount = (long) study.getMemberStudies().size();
+            this.memberCount = (long) study.getMemberStudies().stream()
+                    .filter(memberStudy -> memberStudy.getStatus().equals(ApplicationStatus.APPROVED))
+                    .toList()
+                    .size();
             this.heartCount = (long) study.getHeartCount();
             this.hitNum = study.getHitNum();
             this.maxPeople = study.getMaxPeople();

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
@@ -4,6 +4,7 @@ import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.ApplicationStatus;
 import com.example.spot.domain.enums.Gender;
 import com.example.spot.domain.enums.ThemeType;
+import com.example.spot.domain.mapping.PreferredStudy;
 import com.example.spot.domain.study.Study;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,6 +25,7 @@ public class StudyInfoResponseDTO {
         private final Long hitNum;
         private final Integer heartCount;
         private final Integer memberCount;
+        private final Boolean isLiked;
         private final Long maxPeople;
         private final Gender gender;
         private final Integer minAge;
@@ -36,7 +38,7 @@ public class StudyInfoResponseDTO {
 
         @Builder(access = AccessLevel.PRIVATE)
         private StudyInfoDTO(Long studyId, String studyName, StudyOwnerDTO studyOwner,
-                             Long hitNum, Integer heartCount, Integer memberCount, Long maxPeople, Gender gender,
+                             Long hitNum, Integer heartCount, Integer memberCount, Boolean isLiked, Long maxPeople, Gender gender,
                              Integer minAge, Integer maxAge, Integer fee, Boolean isOnline,
                              List<ThemeType> themes, String goal, String introduction) {
             this.studyId = studyId;
@@ -45,6 +47,7 @@ public class StudyInfoResponseDTO {
             this.hitNum = hitNum;
             this.heartCount = heartCount;
             this.memberCount = memberCount;
+            this.isLiked = isLiked;
             this.maxPeople = maxPeople;
             this.gender = gender;
             this.minAge = minAge;
@@ -68,6 +71,9 @@ public class StudyInfoResponseDTO {
                             .filter(memberStudy -> memberStudy.getStatus().equals(ApplicationStatus.APPROVED))
                             .toList()
                             .size())
+                    .isLiked(study.getPreferredStudies().stream()
+                            .map(PreferredStudy::getMember)
+                            .anyMatch(s -> s.getId().equals(member.getId())))
                     .maxPeople(study.getMaxPeople())
                     .gender(study.getGender())
                     .minAge(study.getMinAge())

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
@@ -25,7 +25,6 @@ public class StudyInfoResponseDTO {
         private final Long hitNum;
         private final Integer heartCount;
         private final Integer memberCount;
-        private final Boolean isLiked;
         private final Long maxPeople;
         private final Gender gender;
         private final Integer minAge;
@@ -47,7 +46,6 @@ public class StudyInfoResponseDTO {
             this.hitNum = hitNum;
             this.heartCount = heartCount;
             this.memberCount = memberCount;
-            this.isLiked = isLiked;
             this.maxPeople = maxPeople;
             this.gender = gender;
             this.minAge = minAge;
@@ -71,9 +69,6 @@ public class StudyInfoResponseDTO {
                             .filter(memberStudy -> memberStudy.getStatus().equals(ApplicationStatus.APPROVED))
                             .toList()
                             .size())
-                    .isLiked(study.getPreferredStudies().stream()
-                            .map(PreferredStudy::getMember)
-                            .anyMatch(s -> s.getId().equals(member.getId())))
                     .maxPeople(study.getMaxPeople())
                     .gender(study.getGender())
                     .minAge(study.getMinAge())

--- a/src/test/java/com/example/spot/service/study/StudyQueryServiceTest.java
+++ b/src/test/java/com/example/spot/service/study/StudyQueryServiceTest.java
@@ -2,6 +2,7 @@ package com.example.spot.service.study;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
@@ -31,6 +32,7 @@ import com.example.spot.repository.RegionStudyRepository;
 import com.example.spot.repository.StudyRepository;
 import com.example.spot.repository.StudyThemeRepository;
 import com.example.spot.repository.ThemeRepository;
+import com.example.spot.security.utils.SecurityUtils;
 import com.example.spot.web.dto.search.SearchRequestDTO.SearchRequestStudyDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.StudyPreviewDTO;
 import java.util.HashMap;
@@ -49,6 +51,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.parameters.P;
 
 @ExtendWith(MockitoExtension.class)
@@ -531,6 +536,16 @@ class StudyQueryServiceTest {
         when(studyRepository.countStudyByConditions(searchConditions, sortBy))
             .thenReturn(2L);
 
+        // SecurityContext와 Authentication을 모킹
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getName()).thenReturn("1"); // 현재 사용자 ID를 1로 가정
+
+        SecurityContextHolder.setContext(securityContext);
+
         // when
         StudyPreviewDTO result = studyQueryService.findRecruitingStudiesByConditions(pageable, request, sortBy);
 
@@ -590,8 +605,20 @@ class StudyQueryServiceTest {
         when(studyRepository.countAllByTitleContaining(keyword, sortBy))
             .thenReturn(1L);
 
+        // SecurityContext와 Authentication을 모킹
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getName()).thenReturn("1"); // 현재 사용자 ID를 1로 가정
+
+        SecurityContextHolder.setContext(securityContext);
+
         // when
         StudyPreviewDTO result = studyQueryService.findStudiesByKeyword(pageable, keyword, sortBy);
+
+
 
         // then
         assertNotNull(result);
@@ -619,6 +646,15 @@ class StudyQueryServiceTest {
             .thenReturn(List.of(study1));
         when(studyRepository.countStudyByStudyTheme(List.of(studyTheme), sortBy))
             .thenReturn(1L);
+        // SecurityContext와 Authentication을 모킹
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getName()).thenReturn("1"); // 현재 사용자 ID를 1로 가정
+
+        SecurityContextHolder.setContext(securityContext);
 
         // when
         StudyPreviewDTO result = studyQueryService.findStudiesByTheme(pageable, themeType, sortBy);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈 번호, #이슈 링크 https://github.com/SPOTeam/Server/issues/148

<br/>

## 🔎 작업 내용

1. memberCount 및 isLike 조회 시 반영 안되는 오류 수정

<br/>
