### PR TITLE
[FIX] 찜한 스터디 조회 시, 비활성화 된 찜 스터디도 조회 되는 오류 수정

### DIFF
--- a/src/main/java/com/example/spot/repository/PreferredStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/PreferredStudyRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 // 찜한 스터디
 public interface PreferredStudyRepository extends JpaRepository<PreferredStudy, Long> {
 
-    List<PreferredStudy> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+    List<PreferredStudy> findByMemberIdAndStudyLikeStatusOrderByCreatedAtDesc(Long memberId, StudyLikeStatus studyLikeStatus);
     Optional<PreferredStudy> findByMemberIdAndStudyId(Long memberId, Long studyId);
 
     long countByMemberId(Long memberId);

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.spot.domain.Member;
 import com.example.spot.domain.Region;
 import com.example.spot.domain.Theme;
 import com.example.spot.domain.enums.ApplicationStatus;
+import com.example.spot.domain.enums.StudyLikeStatus;
 import com.example.spot.domain.enums.StudySortBy;
 import com.example.spot.domain.enums.ThemeType;
 import com.example.spot.domain.mapping.MemberStudy;
@@ -286,7 +287,8 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
     @Override
     public StudyPreviewDTO findLikedStudies(Long memberId) {
-        List<PreferredStudy> preferredStudyList = preferredStudyRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+        List<PreferredStudy> preferredStudyList = preferredStudyRepository.findByMemberIdAndStudyLikeStatusOrderByCreatedAtDesc(
+            memberId, StudyLikeStatus.LIKE);
         List<Study> studies = preferredStudyList.stream()
             .map(PreferredStudy::getStudy)
             .toList();

--- a/src/test/java/com/example/spot/service/study/StudyQueryServiceTest.java
+++ b/src/test/java/com/example/spot/service/study/StudyQueryServiceTest.java
@@ -576,7 +576,7 @@ class StudyQueryServiceTest {
             .studyLikeStatus(StudyLikeStatus.LIKE)
             .build();
 
-        when(preferredStudyRepository.findByMemberIdOrderByCreatedAtDesc(member.getId()))
+        when(preferredStudyRepository.findByMemberIdAndStudyLikeStatusOrderByCreatedAtDesc(member.getId(), StudyLikeStatus.LIKE))
             .thenReturn(List.of(preferredStudy1, preferredStudy2));
         when(preferredStudyRepository.countByMemberId(member.getId()))
             .thenReturn(2L);
@@ -587,7 +587,7 @@ class StudyQueryServiceTest {
         // then
         assertNotNull(result);
         assertEquals(2, result.getTotalElements());
-        verify(preferredStudyRepository).findByMemberIdOrderByCreatedAtDesc(member.getId());
+        verify(preferredStudyRepository).findByMemberIdAndStudyLikeStatusOrderByCreatedAtDesc(member.getId(), StudyLikeStatus.LIKE);
 
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈 번호, #이슈 링크 https://github.com/SPOTeam/Server/issues/154

<br/>

## 🔎 작업 내용

1. StudyQueryService 찜 한 스터디 조회 로직 수정

