### PR TITLE
[REFACTOR] 스터디 관련 요구사항 반영

### DIFF
--- a/src/main/java/com/example/spot/domain/enums/ApplicationStatus.java
+++ b/src/main/java/com/example/spot/domain/enums/ApplicationStatus.java
@@ -3,10 +3,6 @@ package com.example.spot.domain.enums;
 public enum ApplicationStatus {
     APPLIED, // 신청 승인 대기
     APPROVED, // 신청 승인 완료
-
     AWAITING_SELF_APPROVAL, // 본인 승인 대기
-
     REJECTED, // 신청 거절
-    ONGOING,  // 스터디 진행 중
-
 }

--- a/src/main/java/com/example/spot/domain/enums/ApplicationStatus.java
+++ b/src/main/java/com/example/spot/domain/enums/ApplicationStatus.java
@@ -7,7 +7,6 @@ public enum ApplicationStatus {
     AWAITING_SELF_APPROVAL, // 본인 승인 대기
 
     REJECTED, // 신청 거절
-    CANCELED, // 신청 취소
     ONGOING,  // 스터디 진행 중
 
 }

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -12,10 +12,7 @@ import java.util.Optional;
 @Repository
 public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> {
 
-    List<MemberStudy> findByMemberId(Long memberId);
     List<MemberStudy> findByMemberIdAndStatusNot(Long memberId, ApplicationStatus status);
-
-    List<MemberStudy> findByStudyId(Long studyId);
 
     List<MemberStudy> findAllByMemberIdAndStatus(Long memberId, ApplicationStatus status);
 
@@ -25,8 +22,6 @@ public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> 
 
     Optional<MemberStudy> findByMemberIdAndStudyIdAndStatus(Long memberId, Long studyId, ApplicationStatus status);
 
-    Optional<MemberStudy> findByMemberIdAndStudyId(Long memberId, Long studyId);
-
     Optional<MemberStudy> findByMemberIdAndStudyIdAndIsOwned(Long memberId, Long studyId, Boolean isOwned);
 
     long countByStatusAndStudyId(ApplicationStatus status, Long studyId);
@@ -35,5 +30,4 @@ public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> 
 
     boolean existsByMemberIdAndStudyIdAndStatus(Long memberId, Long studyId, ApplicationStatus applicationStatus);
 
-    boolean existsByMemberIdAndStudyId(Long memberId, Long studyId);
 }

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> {
 
     List<MemberStudy> findByMemberId(Long memberId);
+    List<MemberStudy> findByMemberIdAndStatusNot(Long memberId, ApplicationStatus status);
 
     List<MemberStudy> findByStudyId(Long studyId);
 

--- a/src/main/java/com/example/spot/repository/NotificationRepository.java
+++ b/src/main/java/com/example/spot/repository/NotificationRepository.java
@@ -15,7 +15,7 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Optional<Notification> findByMemberIdAndStudyIdAndType(Long memberId, Long studyId, NotifyType type);
     List<Notification> findByMemberIdAndTypeNot(Long memberId, Pageable pageable, NotifyType type);
-    List<Notification> findByMemberIdAndType(Long memberId, Pageable pageable, NotifyType type);
+    List<Notification> findByMemberIdAndTypeAndIsChecked(Long memberId, Pageable pageable, NotifyType type, boolean isChecked);
 
     List<Notification> findByType(NotifyType type);
 }

--- a/src/main/java/com/example/spot/repository/NotificationRepository.java
+++ b/src/main/java/com/example/spot/repository/NotificationRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    Optional<Notification> findByMemberIdAndStudyIdAndType(Long memberId, Long studyId, NotifyType type);
+    Optional<Notification> findByMemberIdAndStudyIdAndTypeAndIsChecked(Long memberId, Long studyId, NotifyType type, boolean isChecked);
     List<Notification> findByMemberIdAndTypeNot(Long memberId, Pageable pageable, NotifyType type);
     List<Notification> findByMemberIdAndTypeAndIsChecked(Long memberId, Pageable pageable, NotifyType type, boolean isChecked);
 

--- a/src/main/java/com/example/spot/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/spot/repository/RefreshTokenRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long>{
     Optional<RefreshToken> findByToken(String token);
     void deleteByMemberId(Long memberId);
+    void deleteAllByMemberId(Long memberId);
 
     boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -128,6 +128,8 @@ public class MemberServiceImpl implements MemberService {
     }
 
     private void saveRefreshToken(Member member, TokenDTO token) {
+        if (refreshTokenRepository.existsByMemberId(member.getId()))
+            refreshTokenRepository.deleteAllByMemberId(member.getId());
         RefreshToken refreshToken = RefreshToken.builder()
             .memberId(member.getId())
             .token(token.getRefreshToken())

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
@@ -74,7 +74,7 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_NOT_FOUND));
 
-        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyId(memberId, studyId)
+        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyIdAndStatus(memberId, studyId, ApplicationStatus.APPROVED)
                 .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_MEMBER_NOT_FOUND));
 
         // 참여가 승인되지 않은 스터디는 탈퇴할 수 없음
@@ -110,7 +110,7 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
         if (!isOwner(SecurityUtils.getCurrentUserId(), studyId))
             throw new GeneralException(ErrorStatus._ONLY_STUDY_OWNER_CAN_ACCESS_APPLICANTS);
 
-        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyId(memberId, studyId)
+        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyIdAndStatus(memberId, studyId, ApplicationStatus.APPLIED)
             .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_APPLICANT_NOT_FOUND));
 
         if (memberStudy.getIsOwned())
@@ -155,7 +155,7 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
         if (!isOwner(SecurityUtils.getCurrentUserId(), studyId))
             throw new GeneralException(ErrorStatus._ONLY_STUDY_OWNER_CAN_ACCESS_APPLICANTS);
 
-        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyId(memberId, studyId)
+        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyIdAndStatus(memberId, studyId, ApplicationStatus.APPLIED)
             .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_APPLICANT_NOT_FOUND));
 
         if (memberStudy.getIsOwned())

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
@@ -214,7 +214,7 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
         // 알림 생성
 
         // 스터디에 참여중인 회원들에게 알림 전송 위해 회원 조회
-        List<Member> members = memberStudyRepository.findByStudyId(studyId).stream()
+        List<Member> members = memberStudyRepository.findAllByStudyIdAndStatus(studyId, ApplicationStatus.APPROVED).stream()
             .map(MemberStudy::getMember)
             .toList();
 
@@ -747,7 +747,7 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
 
         // 스터디 회원의 To-Do List 중 하나가 완료 되면, 해당 스터디의 모든 회원에게 알림 전송
         if (toDoList.isDone()){
-            List<Member> members = memberStudyRepository.findByStudyId(studyId).stream()
+            List<Member> members = memberStudyRepository.findAllByStudyIdAndStatus(studyId, ApplicationStatus.APPROVED).stream()
                 .map(MemberStudy::getMember)
                 .toList();
 

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryServiceImpl.java
@@ -157,7 +157,7 @@ public class MemberStudyQueryServiceImpl implements MemberStudyQueryService {
             throw new GeneralException(ErrorStatus._ALREADY_STUDY_MEMBER);
 
         return StudyApplicantDTO.builder()
-            .isApplied(memberStudyRepository.existsByMemberIdAndStudyId(currentUserId, studyId))
+            .isApplied(memberStudyRepository.existsByMemberIdAndStudyIdAndStatus(currentUserId, studyId, ApplicationStatus.APPLIED))
             .studyId(studyId)
             .build();
 
@@ -188,7 +188,7 @@ public class MemberStudyQueryServiceImpl implements MemberStudyQueryService {
                 .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_QUIZ_NOT_FOUND));
 
         //=== Feature ===//
-        List<StudyQuizResponseDTO.StudyMemberDTO> studyMembers = memberStudyRepository.findByStudyId(studyId).stream()
+        List<StudyQuizResponseDTO.StudyMemberDTO> studyMembers = memberStudyRepository.findAllByStudyIdAndStatus(studyId, ApplicationStatus.APPROVED).stream()
                 .map(memberStudy -> {
                     List<MemberAttendance> attendanceList = memberAttendanceRepository.findByQuizIdAndMemberId(quizId, memberStudy.getMember().getId());
                     for (MemberAttendance attendance : attendanceList) {

--- a/src/main/java/com/example/spot/service/notification/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/notification/NotificationCommandServiceImpl.java
@@ -47,8 +47,8 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
     @Override
     public NotificationProcessDTO joinAppliedStudy(Long studyId, Long memberId, boolean isAccept) {
 
-        Notification notification = notificationRepository.findByMemberIdAndStudyIdAndType(
-            memberId, studyId, NotifyType.STUDY_APPLY).orElseThrow(() -> new GeneralException(ErrorStatus._NOTIFICATION_NOT_FOUND));
+        Notification notification = notificationRepository.findByMemberIdAndStudyIdAndTypeAndIsChecked(
+            memberId, studyId, NotifyType.STUDY_APPLY, false).orElseThrow(() -> new GeneralException(ErrorStatus._NOTIFICATION_NOT_FOUND));
 
         if (notification.getIsChecked())
             throw new GeneralException(ErrorStatus._NOTIFICATION_ALREADY_READ);

--- a/src/main/java/com/example/spot/service/notification/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/notification/NotificationQueryServiceImpl.java
@@ -32,8 +32,8 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
     // 신청한 스터디 알림 전체 조회
     @Override
     public StduyNotificationListDTO getAllAppliedStudyNotification(Long memberId, Pageable pageable) {
-        List<Notification> notifications = notificationRepository.findByMemberIdAndType(
-            memberId, pageable, NotifyType.STUDY_APPLY);
+        List<Notification> notifications = notificationRepository.findByMemberIdAndTypeAndIsChecked(
+            memberId, pageable, NotifyType.STUDY_APPLY, false);
 
         if (notifications.isEmpty())
             throw new GeneralException(ErrorStatus._NOTIFICATION_NOT_FOUND);

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -63,7 +63,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
 
 
         // 이미 신청한 스터디에 다시 신청할 수 없음
-        List<MemberStudy> memberStudyList = memberStudyRepository.findByMemberId(memberId).stream()
+        List<MemberStudy> memberStudyList = memberStudyRepository.findByMemberIdAndStatusNot(memberId, ApplicationStatus.REJECTED).stream()
                 .filter(memberStudy -> study.equals(memberStudy.getStudy()))
                 .toList();
 

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -90,10 +90,9 @@ public class StudyQueryServiceImpl implements StudyQueryService {
             throw new StudyHandler(ErrorStatus._STUDY_OWNER_NOT_FOUND);
         }
 
-        Member member = memberRepository.findById(SecurityUtils.getCurrentUserId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+        Member owner = memberStudyList.get(0).getMember();
 
-        return StudyInfoResponseDTO.StudyInfoDTO.toDTO(study, member);
+        return StudyInfoResponseDTO.StudyInfoDTO.toDTO(study, owner);
     }
 
     @Override

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -100,7 +100,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
         long appliedStudies = memberStudyRepository.countByMemberIdAndStatus(memberId, ApplicationStatus.APPLIED);
-        long ongoingStudies = memberStudyRepository.countByMemberIdAndStatus(memberId, ApplicationStatus.ONGOING);
+        long ongoingStudies = memberStudyRepository.countByMemberIdAndStatus(memberId, ApplicationStatus.APPROVED);
         long myRecruitingStudies = memberStudyRepository.countByMemberIdAndIsOwned(memberId, true);
         return MyPageDTO.builder()
             .name(member.getName())

--- a/src/main/java/com/example/spot/service/studypost/StudyPostCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/studypost/StudyPostCommandServiceImpl.java
@@ -72,7 +72,7 @@ public class StudyPostCommandServiceImpl implements StudyPostCommandService {
                 .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_MEMBER_NOT_FOUND));
 
         // 스터디장만 공지 가능
-        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyId(member.getId(), studyId)
+        MemberStudy memberStudy = memberStudyRepository.findByMemberIdAndStudyIdAndStatus(member.getId(), studyId, ApplicationStatus.APPROVED)
                 .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_MEMBER_NOT_FOUND));
         if (!memberStudy.getIsOwned() && postRequestDTO.getIsAnnouncement()) {
             throw new StudyHandler(ErrorStatus._STUDY_POST_ANNOUNCEMENT_INVALID);

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
@@ -57,11 +57,11 @@ public class StudyInfoResponseDTO {
             this.introduction = introduction;
         }
 
-        public static StudyInfoDTO toDTO(Study study, Member member) {
+        public static StudyInfoDTO toDTO(Study study, Member owner) {
             return StudyInfoDTO.builder()
                     .studyId(study.getId())
                     .studyName(study.getTitle())
-                    .studyOwner(StudyOwnerDTO.toDTO(member))
+                    .studyOwner(StudyOwnerDTO.toDTO(owner))
                     .hitNum(study.getHitNum())
                     .heartCount(study.getHeartCount())
                     .memberCount(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈 번호, #이슈 링크 https://github.com/SPOTeam/Server/issues/157

<br/>

## 🔎 작업 내용

1. 처리된 스터디 알림은 조회 되지 않도록 로직 수정
2. 리프레쉬 토큰이 로그인 마다 DB에 중복 저장 되던 문제 해결
3. 스터디 조회 시, OWNER 정보 얻을 수 있도록 수정
4. 거절 및 취소 한 스터디 다시 신청 가능하도록 수정 
5. 4번으로 인해 memberStudy가 중복 조회 되던 오류 수정 