### PR TITLE
[REFACTOR] 게시글 및 댓글 조회 시 작성자 프로필 이미지 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/spot/service/post/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/post/PostQueryServiceImpl.java
@@ -6,12 +6,12 @@ import com.example.spot.domain.Post;
 import com.example.spot.domain.PostComment;
 import com.example.spot.domain.enums.Board;
 import com.example.spot.domain.mapping.MemberScrap;
-import com.example.spot.repository.MemberRepository;
 import com.example.spot.repository.MemberScrapRepository;
 import com.example.spot.repository.PostCommentRepository;
 import com.example.spot.repository.PostRepository;
 import com.example.spot.web.dto.post.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,6 +26,9 @@ import static com.example.spot.security.utils.SecurityUtils.getCurrentUserId;
 @Service
 @RequiredArgsConstructor
 public class PostQueryServiceImpl implements PostQueryService {
+
+    @Value("${image.post.anonymous.profile}")
+    private String DEFAULT_PROFILE_IMAGE_URL;
 
     private final PostRepository postRepository;
     private final LikedPostQueryService likedPostQueryService;
@@ -66,7 +69,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         CommentResponse commentResponse = getCommentsByPostId(post.getId());
 
         // 조회된 게시글을 PostSingleResponse로 변환하여 반환
-        return PostSingleResponse.toDTO(post, likeCount, scrapCount, commentResponse, likedByCurrentUser, scrapedByCurrentUser);
+        return PostSingleResponse.toDTO(post, likeCount, scrapCount, commentResponse, likedByCurrentUser, scrapedByCurrentUser, DEFAULT_PROFILE_IMAGE_URL);
     }
 
     @Transactional(readOnly = true)
@@ -220,7 +223,7 @@ public class PostQueryServiceImpl implements PostQueryService {
                     boolean likedByCurrentUser = likedPostCommentQueryService.existsByMemberIdAndPostCommentIdAndIsLikedTrue(comment.getId());
                     //현재 사용자 댓글 싫어요 여부
                     boolean dislikedByCurrentUser = likedPostCommentQueryService.existsByMemberIdAndPostCommentIdAndIsLikedFalse(comment.getId());
-                    return CommentDetailResponse.toDTO(comment, likeCount, likedByCurrentUser, dislikedByCurrentUser);
+                    return CommentDetailResponse.toDTO(comment, likeCount, likedByCurrentUser, dislikedByCurrentUser, DEFAULT_PROFILE_IMAGE_URL);
                 })
                 .toList();
 
@@ -241,7 +244,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
         if (boardType == Board.ALL) {
             // ALL 타입일 경우 모든 게시글 조회
-            postScrapPage = memberScrapRepository.findByMemberId(currentUserId,pageable);
+            postScrapPage = memberScrapRepository.findByMemberId(currentUserId, pageable);
         } else {
             // 특정 게시판 타입의 게시글 조회
             postScrapPage = memberScrapRepository.findByMemberIdAndPost_Board(currentUserId, boardType, pageable);

--- a/src/main/java/com/example/spot/service/s3/S3ImageService.java
+++ b/src/main/java/com/example/spot/service/s3/S3ImageService.java
@@ -102,7 +102,7 @@ public class S3ImageService {
         String originalFilename = image.getOriginalFilename(); //원본 파일 명
         String extention = "";
         if (originalFilename != null && !originalFilename.isEmpty()) {
-             extention = originalFilename.substring(originalFilename.lastIndexOf(".")); //확장자 명
+             extention = originalFilename.substring(originalFilename.lastIndexOf(".") + 1); //확장자 명
         }
 
         String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename; //변경된 파일 명

--- a/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
@@ -36,6 +36,11 @@ public class CommentDetailResponse {
     private String writer;
 
     @Schema(
+            description = "댓글 작성자 익명 여부입니다."
+    )
+    private boolean anonymous;
+
+    @Schema(
             description = "댓글 작성자 프로필 사진"
     )
     private String profileImage;
@@ -82,6 +87,7 @@ public class CommentDetailResponse {
                 .commentContent(comment.getContent())
                 .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
                 .writer(writerName)
+                .anonymous(comment.isAnonymous())
                 .writtenTime(comment.getCreatedAt().toString())
                 .likeCount(likeCount)
                 .likedByCurrentUser(likedByCurrentUser)

--- a/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
@@ -73,10 +73,12 @@ public class CommentDetailResponse {
     public static CommentDetailResponse toDTO(PostComment comment, long likeCount, boolean likedByCurrentUser, boolean dislikedByCurrentUser) {
         // 작성자가 익명인지 확인하여 작성자 이름 설정
         String writerName = judgeAnonymous(comment.isAnonymous(), comment.getMember().getName());
+        // 작성자가 익명인지 확인하여 프로필 반환
+        String writerImage = anonymousProfileImage(comment.isAnonymous(), comment.getMember().getProfileImage());
 
         return CommentDetailResponse.builder()
                 .commentId(comment.getId())
-                .profileImage(comment.getMember().getProfileImage())
+                .profileImage(writerImage)
                 .commentContent(comment.getContent())
                 .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
                 .writer(writerName)
@@ -94,5 +96,14 @@ public class CommentDetailResponse {
         }
 
         return writer;
+    }
+
+    public static String anonymousProfileImage(Boolean isAnonymous, String profileImage) {
+
+        if (isAnonymous) {
+            return "https://spot-bucket-01.s3.ap-northeast-2.amazonaws.com/6f12ba3a-7Component%2017.png";
+        }
+
+        return profileImage;
     }
 }

--- a/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
@@ -75,11 +75,11 @@ public class CommentDetailResponse {
 //    )
 //    private int disLikeCount;
 
-    public static CommentDetailResponse toDTO(PostComment comment, long likeCount, boolean likedByCurrentUser, boolean dislikedByCurrentUser) {
+    public static CommentDetailResponse toDTO(PostComment comment, long likeCount, boolean likedByCurrentUser, boolean dislikedByCurrentUser, String defaultProfileImageUrl) {
         // 작성자가 익명인지 확인하여 작성자 이름 설정
         String writerName = judgeAnonymous(comment.isAnonymous(), comment.getMember().getName());
         // 작성자가 익명인지 확인하여 프로필 반환
-        String writerImage = anonymousProfileImage(comment.isAnonymous(), comment.getMember().getProfileImage());
+        String writerImage = anonymousProfileImage(comment.isAnonymous(), comment.getMember().getProfileImage(), defaultProfileImageUrl);
 
         return CommentDetailResponse.builder()
                 .commentId(comment.getId())
@@ -104,10 +104,9 @@ public class CommentDetailResponse {
         return writer;
     }
 
-    public static String anonymousProfileImage(Boolean isAnonymous, String profileImage) {
-
+    public static String anonymousProfileImage(Boolean isAnonymous, String profileImage, String defaultProfileImageUrl) {
         if (isAnonymous) {
-            return "https://spot-bucket-01.s3.ap-northeast-2.amazonaws.com/6f12ba3a-7Component%2017.png";
+            return defaultProfileImageUrl;
         }
 
         return profileImage;

--- a/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/CommentDetailResponse.java
@@ -36,6 +36,11 @@ public class CommentDetailResponse {
     private String writer;
 
     @Schema(
+            description = "댓글 작성자 프로필 사진"
+    )
+    private String profileImage;
+
+    @Schema(
             description = "작성 시간입니다.",
             type = "string",
             format = "date-time",
@@ -71,6 +76,7 @@ public class CommentDetailResponse {
 
         return CommentDetailResponse.builder()
                 .commentId(comment.getId())
+                .profileImage(comment.getMember().getProfileImage())
                 .commentContent(comment.getContent())
                 .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
                 .writer(writerName)

--- a/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
@@ -23,6 +23,11 @@ public class PostSingleResponse {
     private String writer;
 
     @Schema(
+            description = "댓글 작성자 프로필 사진"
+    )
+    private String profileImage;
+
+    @Schema(
             description = "작성 시간입니다.",
             type = "string",
             format = "date-time",
@@ -103,6 +108,7 @@ public class PostSingleResponse {
         return PostSingleResponse.builder()
                 .type(post.getBoard().name())
                 .writer(writerName)
+                .profileImage(post.getMember().getProfileImage())
                 .writtenTime(post.getCreatedAt())
                 .scrapCount(scrapCount)
                 .scrapedByCurrentUser(scrapedByCurrentUser)

--- a/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
@@ -14,6 +14,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class PostSingleResponse {
 
+    @Schema(
+            description = "게시글 타입입니다."
+    )
     private String type;
 
     @Schema(
@@ -106,20 +109,20 @@ public class PostSingleResponse {
         return writer;
     }
 
-    public static String anonymousProfileImage(Boolean isAnonymous, String profileImage) {
+    public static String anonymousProfileImage(Boolean isAnonymous, String profileImage, String defaultProfileImageUrl) {
 
         if (isAnonymous) {
-            return "https://spot-bucket-01.s3.ap-northeast-2.amazonaws.com/6f12ba3a-7Component%2017.png";
+            return defaultProfileImageUrl;
         }
 
         return profileImage;
     }
 
-    public static PostSingleResponse toDTO(Post post, long likeCount, long scrapCount, CommentResponse commentResponse, boolean likedByCurrentUser, boolean scrapedByCurrentUser) {
+    public static PostSingleResponse toDTO(Post post, long likeCount, long scrapCount, CommentResponse commentResponse, boolean likedByCurrentUser, boolean scrapedByCurrentUser, String defaultProfileImageUrl) {
         // 작성자가 익명인지 확인하여 작성자 이름 설정
         String writerName = judgeAnonymous(post.isAnonymous(), post.getMember().getName());
         // 작성자가 익명인지 확인하여 프로필 반환
-        String writerImage = anonymousProfileImage(post.isAnonymous(), post.getMember().getProfileImage());
+        String writerImage = anonymousProfileImage(post.isAnonymous(), post.getMember().getProfileImage(), defaultProfileImageUrl);
 
 
         return PostSingleResponse.builder()

--- a/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
@@ -101,14 +101,26 @@ public class PostSingleResponse {
         return writer;
     }
 
+    public static String anonymousProfileImage(Boolean isAnonymous, String profileImage) {
+
+        if (isAnonymous) {
+            return "https://spot-bucket-01.s3.ap-northeast-2.amazonaws.com/6f12ba3a-7Component%2017.png";
+        }
+
+        return profileImage;
+    }
+
     public static PostSingleResponse toDTO(Post post, long likeCount, long scrapCount, CommentResponse commentResponse, boolean likedByCurrentUser, boolean scrapedByCurrentUser) {
         // 작성자가 익명인지 확인하여 작성자 이름 설정
         String writerName = judgeAnonymous(post.isAnonymous(), post.getMember().getName());
+        // 작성자가 익명인지 확인하여 프로필 반환
+        String writerImage = anonymousProfileImage(post.isAnonymous(), post.getMember().getProfileImage());
+
 
         return PostSingleResponse.builder()
                 .type(post.getBoard().name())
                 .writer(writerName)
-                .profileImage(post.getMember().getProfileImage())
+                .profileImage(writerImage)
                 .writtenTime(post.getCreatedAt())
                 .scrapCount(scrapCount)
                 .scrapedByCurrentUser(scrapedByCurrentUser)

--- a/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
@@ -23,7 +23,12 @@ public class PostSingleResponse {
     private String writer;
 
     @Schema(
-            description = "댓글 작성자 프로필 사진"
+            description = "게시글 작성자 익명 여부입니다."
+    )
+    private boolean anonymous;
+
+    @Schema(
+            description = "댓글 작성자 프로필 사진입니다."
     )
     private String profileImage;
 
@@ -120,6 +125,7 @@ public class PostSingleResponse {
         return PostSingleResponse.builder()
                 .type(post.getBoard().name())
                 .writer(writerName)
+                .anonymous(post.isAnonymous())
                 .profileImage(writerImage)
                 .writtenTime(post.getCreatedAt())
                 .scrapCount(scrapCount)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>  #163
<br/>

## 🔎 작업 내용

1. 게시글 및 댓글 조회 시 작성자 프로필 이미지 반환하도록 수정
2. 익명 작성자 여부 확인 후  익명 프로필 사진 반환
3. 익명 작성자 여부 반환

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
