### PR TITLE
[MODIFY] 스터디 게시글 댓글 수 조회 방식 변경 & DTO에 이름 추가

### DIFF
--- a/src/main/java/com/example/spot/domain/study/StudyPost.java
+++ b/src/main/java/com/example/spot/domain/study/StudyPost.java
@@ -59,6 +59,7 @@ public class StudyPost extends BaseEntity {
     @Column(nullable = false)
     private Integer hitNum;
 
+    @Setter
     @Column(nullable = false)
     private Integer commentNum;
 
@@ -141,12 +142,6 @@ public class StudyPost extends BaseEntity {
 
     public void minusLikeNum() {
         likeNum--;
-        member.updateStudyPost(this);
-        study.updateStudyPost(this);
-    }
-
-    public void plusCommentNum() {
-        commentNum++;
         member.updateStudyPost(this);
         study.updateStudyPost(this);
     }

--- a/src/main/java/com/example/spot/service/studypost/StudyPostCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/studypost/StudyPostCommandServiceImpl.java
@@ -300,7 +300,7 @@ public class StudyPostCommandServiceImpl implements StudyPostCommandService {
 
         studyPostCommentRepository.save(studyPostComment);
 
-        studyPost.plusCommentNum();
+        studyPost.setCommentNum(studyPostCommentRepository.findAllByStudyPostId(postId).size());
         studyPostRepository.save(studyPost);
 
         studyPost.addComment(studyPostComment);
@@ -349,7 +349,7 @@ public class StudyPostCommandServiceImpl implements StudyPostCommandService {
 
         studyPostCommentRepository.save(studyPostComment);
 
-        studyPost.plusCommentNum();
+        studyPost.setCommentNum(studyPostCommentRepository.findAllByStudyPostId(postId).size());
         studyPostRepository.save(studyPost);
 
         studyPost.addComment(studyPostComment);

--- a/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostResDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostResDTO.java
@@ -88,6 +88,7 @@ public class StudyPostResDTO {
     public static class PostDetailDTO {
 
         private final Long memberId;
+        private final String name;
         private final Long postId;
         private final String title;
         private final String content;
@@ -103,6 +104,7 @@ public class StudyPostResDTO {
         public static PostDetailDTO toDTO(StudyPost studyPost, boolean isLiked) {
             return PostDetailDTO.builder()
                     .memberId(studyPost.getMember().getId())
+                    .name(studyPost.getMember().getName())
                     .postId(studyPost.getId())
                     .title(studyPost.getTitle())
                     .content(studyPost.getContent())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 

- #167 

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.

- 스터디 게시글 댓글 수 조회 방식 변경 (+1 방식이 아닌 DB에서 댓글 수를 불러오는 방식)
- 스터디 게시글 조회 DTO에 작성자 이름 추가

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
