### PR TITLE
[fix] 댓글순 인기글 반환 안되는 오류 해결

### DIFF
--- a/src/main/java/com/example/spot/repository/querydsl/impl/PostRepositoryImpl.java
+++ b/src/main/java/com/example/spot/repository/querydsl/impl/PostRepositoryImpl.java
@@ -30,7 +30,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     public List<Post> findTopByOrderByCommentCountDesc() {
         return jpaQueryFactory
                 .selectFrom(post)
-                .leftJoin(post.postCommentList, comment)
+                .leftJoin(post.postCommentList, comment).fetchJoin()
                 //.groupBy(post)
                 .orderBy(post.postCommentList.size().desc())
                 //.orderBy(comment.count().desc(), post.id.desc())//댓글 수가 같을 경우 게시글 최신순(게시글 아이디 큰 순)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #183

<br/>

## 🔎 작업 내용

> 댓글순 인기글 반환 안되는 오류 해결

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
