### PR TITLE
[FEAT] 일반 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // SMS
+    implementation 'net.nurigo:sdk:4.3.0'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "COMMON4010", "만료된 리프레시 토큰입니다."),
     _NULL_VALUE(HttpStatus.BAD_REQUEST, "COMMON4011", "값이 입력되지 않았습니다."),
     _VALUE_RANGE_EXCEEDED(HttpStatus.BAD_REQUEST, "COMMON4012", "값이 지정된 범위를 초과합니다."),
+    _TERMS_NOT_AGREED(HttpStatus.FORBIDDEN, "COMMON4013", "이용 약관이 동의되지 않았습니다."),
 
     //멤버 관련 에러
     _MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원을 찾을 수 없습니다."),
@@ -37,6 +38,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBER_THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4009", "해당하는 회원의 관심 테마를 찾을 수 없습니다."),
     _MEMBER_REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4010", "해당하는 회원의 관심 지역을 찾을 수 없습니다."),
     _MEMBER_STUDY_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4011", "해당하는 회원의 스터디 이유를 찾을 수 없습니다."),
+    _MEMBER_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "MEMBER4012", "전화번호 인증에 실패하였습니다."),
+    _MEMBER_PHONE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4013", "해당 전화번호로 가입된 회원이 이미 존재합니다."),
+    _MEMBER_PW_AND_PW_CHECK_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "MEMBER4014", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    _MEMBER_PHONE_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "MEMBER4015", "인증되지 않은 전화번호입니다."),
 
     //스터디 관련 에러
     _STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY4001", "스터디를 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
@@ -24,6 +24,7 @@ public enum SuccessStatus implements BaseCode {
     _MEMBER_THEME_UPDATE(HttpStatus.OK, "MEMBER2006", "회원 테마 수정 완료"),
     _MEMBER_REGION_UPDATE(HttpStatus.OK, "MEMBER2007", "회원 지역 수정 완료"),
     _MEMBER_INFO_UPDATE(HttpStatus.OK, "MEMBER2008", "회원 정보 수정 완료"),
+    _MEMBER_PHONE_VERIFIED(HttpStatus.OK, "MEMBER2009", "회원 전화번호 인증 완료"),
 
     //스터디 게시글 관련 응답
     _STUDY_POST_CREATED(HttpStatus.CREATED, "STUDYPOST3001", "스터디 게시글 작성 완료"),

--- a/src/main/java/com/example/spot/config/WebSecurity.java
+++ b/src/main/java/com/example/spot/config/WebSecurity.java
@@ -4,6 +4,7 @@ package com.example.spot.config;
 import com.example.spot.security.filters.JwtAuthenticationFilter;
 import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.service.member.MemberService;
+import com.example.spot.service.member.UserDetailsServiceCustom;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.annotation.Bean;
@@ -21,6 +22,7 @@ public class WebSecurity {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService;
+    private final UserDetailsServiceCustom userDetailsService;
     @Bean
     protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
 
@@ -30,6 +32,8 @@ public class WebSecurity {
         http.authorizeHttpRequests((authz) -> authz
                 .requestMatchers(new AntPathRequestMatcher("/api/**")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/actuator/**")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/spot/sign-up/send-verification-code")).permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/spot/sign-up/verify")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/spot/reissue")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/spot/login/kakao", "GET")).permitAll()
                 .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/kakao", "GET")).permitAll()
@@ -49,6 +53,6 @@ public class WebSecurity {
     }
 
     private JwtAuthenticationFilter getJwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtTokenProvider, memberService);
+        return new JwtAuthenticationFilter(jwtTokenProvider, memberService, userDetailsService);
     }
 }

--- a/src/main/java/com/example/spot/domain/Member.java
+++ b/src/main/java/com/example/spot/domain/Member.java
@@ -46,6 +46,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String password;
 
+    @Column(nullable = false, length = 8)
+    private String nickname;
+
     @Column(nullable = false, length = 50, unique = true)
     private String email;
 
@@ -53,7 +56,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 5)
     private Carrier carrier;
 
-    @Column(nullable = false, length = 15)
+    @Column(nullable = false, length = 15, unique = true)
     private String phone;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/spot/domain/auth/TempUserDetails.java
+++ b/src/main/java/com/example/spot/domain/auth/TempUserDetails.java
@@ -1,0 +1,52 @@
+package com.example.spot.domain.auth;
+
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TempUserDetails implements UserDetails {
+
+    private String phone; // 사용자 이름
+    private Collection<? extends GrantedAuthority> authorities; // 사용자 권한
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return phone;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/example/spot/domain/auth/VerificationCode.java
+++ b/src/main/java/com/example/spot/domain/auth/VerificationCode.java
@@ -2,6 +2,7 @@ package com.example.spot.domain.auth;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -9,23 +10,19 @@ import java.time.LocalDateTime;
 public class VerificationCode {
 
     private final String phone;
-    private String tempToken;
+
+    @Setter
     private String code;
+
+    @Setter
+    private String tempToken;
+
+    @Setter
     private LocalDateTime expiredAt;
 
     @Builder
     public VerificationCode(String phone, String code, LocalDateTime expiredAt) {
         this.phone = phone;
         this.code = code;
-        this.expiredAt = expiredAt;
-    }
-
-    public void resetVerificationCode(String code, LocalDateTime expiredAt) {
-        this.code = code;
-        this.expiredAt = expiredAt;
-    }
-
-    public void addTempToken(String tempToken) {
-        this.tempToken = tempToken;
     }
 }

--- a/src/main/java/com/example/spot/domain/auth/VerificationCode.java
+++ b/src/main/java/com/example/spot/domain/auth/VerificationCode.java
@@ -1,0 +1,31 @@
+package com.example.spot.domain.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class VerificationCode {
+
+    private final String phone;
+    private String tempToken;
+    private String code;
+    private LocalDateTime expiredAt;
+
+    @Builder
+    public VerificationCode(String phone, String code, LocalDateTime expiredAt) {
+        this.phone = phone;
+        this.code = code;
+        this.expiredAt = expiredAt;
+    }
+
+    public void resetVerificationCode(String code, LocalDateTime expiredAt) {
+        this.code = code;
+        this.expiredAt = expiredAt;
+    }
+
+    public void addTempToken(String tempToken) {
+        this.tempToken = tempToken;
+    }
+}

--- a/src/main/java/com/example/spot/repository/MemberRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberRepository.java
@@ -10,7 +10,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByPhone(String phone);
+
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByName(String name);
+
 }

--- a/src/main/java/com/example/spot/repository/verification/VerificationCodeRepository.java
+++ b/src/main/java/com/example/spot/repository/verification/VerificationCodeRepository.java
@@ -1,10 +1,13 @@
 package com.example.spot.repository.verification;
 
+import com.example.spot.domain.auth.VerificationCode;
+import com.example.spot.web.dto.token.TokenResponseDTO;
+
 public interface VerificationCodeRepository {
 
-    public void addVerificationCode(String phone, String code);
+    void addVerificationCode(String phone, String code);
 
-    public String getVerificationCode(String phone);
+    VerificationCode getVerificationCode(String phone);
 
-    public String addTempToken(String tempToken);
+    void setTempToken(TokenResponseDTO.TempTokenDTO tempTokenDTO, VerificationCode existingCode);
 }

--- a/src/main/java/com/example/spot/repository/verification/VerificationCodeRepository.java
+++ b/src/main/java/com/example/spot/repository/verification/VerificationCodeRepository.java
@@ -1,0 +1,10 @@
+package com.example.spot.repository.verification;
+
+public interface VerificationCodeRepository {
+
+    public void addVerificationCode(String phone, String code);
+
+    public String getVerificationCode(String phone);
+
+    public String addTempToken(String tempToken);
+}

--- a/src/main/java/com/example/spot/repository/verification/VerificationCodeRepositoryImpl.java
+++ b/src/main/java/com/example/spot/repository/verification/VerificationCodeRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.example.spot.repository.verification;
+
+import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.handler.MemberHandler;
+import com.example.spot.domain.auth.VerificationCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Repository
+@RequiredArgsConstructor
+public class VerificationCodeRepositoryImpl implements VerificationCodeRepository {
+
+    @Value("${token.temp_token_expiration_time}")
+    private Long TEMP_TOKEN_EXPIRATION_TIME;
+
+    private final List<VerificationCode> verificationCodes = new ArrayList<>();
+
+    @Override
+    public void addVerificationCode(String phone, String code) {
+        if (phone != null && code != null) {
+
+            // 만료기간이 지난 VerificationCode 삭제
+            verificationCodes.removeIf(verificationCode -> verificationCode.getExpiredAt().isBefore(LocalDateTime.now()));
+
+            // 동일한 임시 토큰으로 생성한 코드가 이미 존재하는지 확인
+            VerificationCode existingCode = verificationCodes.stream()
+                    .filter(verificationCode -> verificationCode.getPhone().equals(phone))
+                    .findFirst()
+                    .orElse(null);
+
+            if (existingCode == null) {
+                VerificationCode verificationCode = VerificationCode.builder()
+                        .phone(phone)
+                        .code(code)
+                        .expiredAt(LocalDateTime.now().plus(Duration.ofMillis(TEMP_TOKEN_EXPIRATION_TIME)))
+                        .build();
+                this.verificationCodes.add(verificationCode);
+            } else {
+                existingCode.resetVerificationCode(code, LocalDateTime.now().plus(Duration.ofMillis(TEMP_TOKEN_EXPIRATION_TIME)));
+            }
+
+        }
+    }
+
+    @Override
+    public String getVerificationCode(String phone) {
+
+        VerificationCode code = verificationCodes.stream()
+                .filter(vc -> vc.getPhone().equals(phone))
+                .findFirst()
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_VERIFIED));
+
+        return code.getCode();
+    }
+
+    @Override
+    public String addTempToken(String tempToken) {
+        return "";
+    }
+}

--- a/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/spot/security/filters/JwtAuthenticationFilter.java
@@ -3,8 +3,10 @@ package com.example.spot.security.filters;
 import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.GeneralException;
 import com.example.spot.domain.auth.CustomUserDetails;
+import com.example.spot.domain.auth.TempUserDetails;
 import com.example.spot.service.member.MemberService;
 import com.example.spot.security.utils.JwtTokenProvider;
+import com.example.spot.service.member.UserDetailsServiceCustom;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,15 +28,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberService memberService; // MemberService 주입 추가
+    private final UserDetailsServiceCustom userDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
         try {
+
+            // 임시 토큰 인증 요청 별도 처리
+            if (isTempRequest(request)) {
+                String tempToken = jwtTokenProvider.resolveToken(request);
+                if (isValidToken(tempToken)) {
+                    tempAuthenticateUser(tempToken);
+                }
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 재발행 요청 별도 처리
             if (isReissueRequest(request)) {
                 filterChain.doFilter(request, response);
                 return;
             }
+
+            // 일반 인증 요청 처리
             String token = jwtTokenProvider.resolveToken(request);
             if (isValidToken(token))
                 authenticateUser(token);
@@ -42,6 +59,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (GeneralException e) {
             handleException(response, e);
         }
+    }
+
+    private boolean isTempRequest(HttpServletRequest request) {
+        return Objects.equals(request.getRequestURI(), "/spot/sign-up");
     }
 
     private boolean isReissueRequest(HttpServletRequest request) {
@@ -52,10 +73,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return token != null && jwtTokenProvider.validateToken(token);
     }
 
+    private void tempAuthenticateUser(String tempToken) {
+        String phone = jwtTokenProvider.getPhoneByToken(tempToken);
+        authenticate(phone);
+    }
+
     private void authenticateUser(String token) {
         Long memberId = jwtTokenProvider.getMemberIdByToken(token);
-        CustomUserDetails userDetails = (CustomUserDetails) memberService.loadUserByUsername(memberId.toString());
-        Authentication authentication = jwtTokenProvider.getAuthentication(token, userDetails);
+        authenticate(memberId.toString());
+    }
+
+    private void authenticate(String tempToken) {
+        TempUserDetails userDetails = (TempUserDetails) userDetailsService.loadUserByUsername(tempToken);
+        Authentication authentication = jwtTokenProvider.getAuthentication(tempToken, userDetails);
         log.info("Authenticated user: {}", userDetails.getUsername());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }

--- a/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/spot/security/utils/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package com.example.spot.security.utils;
 
 import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.exception.GeneralException;
+import com.example.spot.web.dto.token.TokenResponseDTO;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -30,6 +31,8 @@ public class JwtTokenProvider {
     private Long ACCESS_TOKEN_EXPIRATION_TIME;
     @Value("${token.refresh_token_expiration_time}")
     private Long REFRESH_TOKEN_EXPIRATION_TIME;
+    @Value("${token.temp_token_expiration_time}")
+    private Long TEMP_TOKEN_EXPIRATION_TIME;
 
     @PostConstruct
     protected void init() {
@@ -49,6 +52,17 @@ public class JwtTokenProvider {
             .build();
     }
 
+    // 전화번호 인증을 위한 임시 토큰 생성
+    public TokenResponseDTO.TempTokenDTO createTempToken(String phone) {
+        Date now = new Date();
+        String tempToken = generateTempToken(phone, now);
+
+        return TokenResponseDTO.TempTokenDTO.builder()
+                .tempToken(tempToken)
+                .tempTokenExpiresIn(TEMP_TOKEN_EXPIRATION_TIME)
+                .build();
+    }
+
     // JWT 토큰 생성 -> 위 createToken 메서드에서 호출
     private String generateToken(Long memberId, Date now, long expirationTime, String tokenType) {
         return Jwts.builder()
@@ -58,6 +72,17 @@ public class JwtTokenProvider {
             .setExpiration(new Date(now.getTime() + expirationTime))
             .signWith(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
             .compact();
+    }
+
+    // JWT 임시 토큰 생성 -> 위 createTempToken 메서드에서 호출
+    private String generateTempToken(String phone, Date now) {
+        return Jwts.builder()
+                .claim("phone", phone)
+                .claim("tokenType", "temp")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + TEMP_TOKEN_EXPIRATION_TIME))
+                .signWith(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
     }
 
     // 토큰 유효성 검사 -> 유효기간 만료 여부 확인
@@ -120,11 +145,20 @@ public class JwtTokenProvider {
     }
 
     public Long getMemberIdByToken(String token) {
-        Claims claims = Jwts.parserBuilder()
-            .setSigningKey(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes()))
-            .build()
-            .parseClaimsJws(token)
-            .getBody();
+        Claims claims = getClaims(token);
         return claims.get("memberId", Long.class);
+    }
+
+    public String getPhoneByToken(String tempToken) {
+        Claims claims = getClaims(tempToken);
+        return claims.get("phone", String.class);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
     }
 }

--- a/src/main/java/com/example/spot/security/utils/SecurityUtils.java
+++ b/src/main/java/com/example/spot/security/utils/SecurityUtils.java
@@ -36,4 +36,12 @@ public class SecurityUtils {
             .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"));
     }
 
+    // 임시 토큰을 발급받은 유저 검증
+    public static String getVerifiedTempUserPhone() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+        return authentication.getName();
+    }
 }

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -1,10 +1,20 @@
 package com.example.spot.service.auth;
 
+import com.example.spot.web.dto.member.MemberRequestDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO;
+import com.example.spot.web.dto.token.TokenResponseDTO;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
 
 public interface AuthService {
 
     // 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급
     TokenDTO reissueToken(String refreshToken);
+
+    void sendVerificationCode(MemberRequestDTO.PhoneDTO phoneDTO);
+
+    TokenResponseDTO.TempTokenDTO verifyPhone(String verificationCode, MemberRequestDTO.PhoneDTO phoneDTO);
+
+    MemberResponseDTO.MemberSignInDTO signUp(MemberRequestDTO.SignUpDTO signUpDTO);
+
 
 }

--- a/src/main/java/com/example/spot/service/member/UserDetailsServiceCustom.java
+++ b/src/main/java/com/example/spot/service/member/UserDetailsServiceCustom.java
@@ -1,0 +1,6 @@
+package com.example.spot.service.member;
+
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface UserDetailsServiceCustom extends UserDetailsService {
+}

--- a/src/main/java/com/example/spot/service/member/UserDetailsServiceCustomImpl.java
+++ b/src/main/java/com/example/spot/service/member/UserDetailsServiceCustomImpl.java
@@ -1,0 +1,27 @@
+package com.example.spot.service.member;
+
+import com.example.spot.domain.auth.TempUserDetails;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserDetailsServiceCustomImpl implements UserDetailsServiceCustom {
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        List<GrantedAuthority> authorities = List.of(
+            new SimpleGrantedAuthority("ROLE_USER")
+        );
+
+        return TempUserDetails.builder()
+                .phone(username)
+                .authorities(authorities)
+                .build();
+    }
+}

--- a/src/main/java/com/example/spot/service/message/MessageService.java
+++ b/src/main/java/com/example/spot/service/message/MessageService.java
@@ -1,0 +1,7 @@
+package com.example.spot.service.message;
+
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+
+public interface MessageService {
+    SingleMessageSentResponse sendMessage(String receiver, String code);
+}

--- a/src/main/java/com/example/spot/service/message/MessageServiceImpl.java
+++ b/src/main/java/com/example/spot/service/message/MessageServiceImpl.java
@@ -1,0 +1,41 @@
+package com.example.spot.service.message;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessageServiceImpl implements MessageService {
+
+    private DefaultMessageService defaultMessageService;
+
+    @Value("${coolsms.api.key}")
+    private String smsApiKey;
+
+    @Value("${coolsms.api.secret}")
+    private String smsSecretKey;
+
+    @Value("${coolsms.api.sender}")
+    private String sender;
+
+    @PostConstruct
+    private void init() {
+        this.defaultMessageService = NurigoApp.INSTANCE.initialize(smsApiKey, smsSecretKey, "https://api.coolsms.co.kr");
+    }
+
+    @Override
+    public SingleMessageSentResponse sendMessage(String receiver, String code) {
+        Message message = new Message();
+        message.setFrom(sender);
+        message.setTo(receiver);
+        message.setText("[SPOT] 인증번호는 " + code + " 입니다.");
+        return this.defaultMessageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+}

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -3,16 +3,17 @@ package com.example.spot.web.controller;
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
 import com.example.spot.service.auth.AuthService;
+import com.example.spot.web.dto.member.MemberRequestDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO;
+import com.example.spot.web.dto.token.TokenResponseDTO;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @Slf4j
@@ -37,18 +38,49 @@ public class AuthController {
         return ApiResponse.onSuccess(SuccessStatus._CREATED, authService.reissueToken(refreshToken));
     }
 
-    @Tag(name = "회원 관리 API - 개발 중", description = "회원 관리 API")
+    @Tag(name = "회원 관리 API - 개발 완료", description = "회원 관리 API")
+    @Operation(summary = "[회원 가입] 일반 회원 가입 인증번호 전송 API",
+            description = """
+            ## [회원 가입] 일반 회원 가입 인증번호 전송 API입니다.
+            입력받은 전화번호로 인증번호가 전송됩니다.
+            """)
+    @PostMapping("/sign-up/send-verification-code")
+    public ApiResponse<Void> sendVerificationCode(
+            @RequestBody @Valid MemberRequestDTO.PhoneDTO phoneDTO) {
+        authService.sendVerificationCode(phoneDTO);
+        return ApiResponse.onSuccess(SuccessStatus._MEMBER_PHONE_VERIFIED);
+    }
+
+    @Tag(name = "회원 관리 API - 개발 완료", description = "회원 관리 API")
+    @Operation(summary = "[회원 가입] 일반 회원 가입 전화번호 인증 API",
+            description = """
+            ## [회원 가입] 일반 회원 가입 전화번호 인증 API입니다.
+            사용자로부터 인증코드와 전화번호를 받아 검증 작업을 수행한 후, 임시 토큰을 반환합니다.
+            임시 토큰은 최대 3분간 유효합니다. 임시 토큰이 만료된 경우 전화번호 재인증이 필요합니다.
+            """)
+    @PostMapping("/sign-up/verify")
+    public ApiResponse<TokenResponseDTO.TempTokenDTO> verifyPhone(
+            @RequestParam String verificationCode,
+            @RequestBody @Valid MemberRequestDTO.PhoneDTO phoneDTO) {
+        TokenResponseDTO.TempTokenDTO tempTokenDTO = authService.verifyPhone(verificationCode, phoneDTO);
+        return ApiResponse.onSuccess(SuccessStatus._MEMBER_PHONE_VERIFIED, tempTokenDTO);
+    }
+
+    @Tag(name = "회원 관리 API - 개발 완료", description = "회원 관리 API")
     @Operation(summary = "[회원 가입] 일반 회원 가입 API",
         description = """
             ## [회원 가입] 일반 회원 가입 API입니다.
-            회원 가입 시, 아이디(이메일)과 비밀번호를 입력하여 회원 가입을 진행합니다.
+            아이디(이메일)과 비밀번호를 입력하여 회원 가입을 진행합니다.
+            전화번호 인증 API로부터 발급 받은 임시 토큰이 Authorization 헤더에 포함되어야 합니다.
             회원 가입에 성공하면, 액세스 토큰과 리프레시 토큰이 발급됩니다.
             액세스 토큰은 사용자의 정보를 인증하는데 사용되며, 리프레시 토큰은 액세스 토큰이 만료된 경우, 액세스 토큰을 재발급 하는데 사용됩니다.
             액세스 토큰이 만료된 경우, 유효한 상태의 리프레시 토큰을 통해 액세스 토큰을 재발급 받을 수 있습니다.
             """)
     @PostMapping("/sign-up")
-    public ApiResponse<TokenDTO> signUp() {
-        return null;
+    public ApiResponse<MemberResponseDTO.MemberSignInDTO> signUp(
+            @RequestBody @Valid MemberRequestDTO.SignUpDTO signUpDTO) {
+        MemberResponseDTO.MemberSignInDTO memberSignUpDTO = authService.signUp(signUpDTO);
+        return ApiResponse.onSuccess(SuccessStatus._MEMBER_CREATED, memberSignUpDTO);
     }
 
     @Tag(name = "회원 관리 API - 개발 중", description = "회원 관리 API")
@@ -60,7 +92,8 @@ public class AuthController {
             액세스 토큰이 만료된 경우, 유효한 상태의 리프레시 토큰을 통해 액세스 토큰을 재발급 받을 수 있습니다.
             """)
     @PostMapping("/login")
-    public ApiResponse<TokenDTO> login() {
+    public ApiResponse<MemberResponseDTO.MemberSignInDTO> login(
+            @RequestBody @Valid MemberRequestDTO.SignInDTO signInDTO) {
         return null;
     }
 

--- a/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
@@ -4,17 +4,69 @@ import com.example.spot.domain.enums.Carrier;
 import com.example.spot.domain.enums.Gender;
 import com.example.spot.domain.enums.Theme;
 import com.example.spot.domain.enums.ThemeType;
+import com.example.spot.validation.annotation.TextLength;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import java.time.LocalDate;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import lombok.*;
 
 public class MemberRequestDTO {
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class PhoneDTO {
+
+        private final Carrier carrier;
+
+        @TextLength(max = 15)
+        private final String phone;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class SignInDTO {
+
+        private final Carrier carrier;
+
+        @TextLength(max = 15)
+        private final String phone;
+
+        @TextLength(max = 100)
+        private final String password;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class SignUpDTO {
+
+        @TextLength(max = 20)
+        private final String name;
+
+        @TextLength(max = 8)
+        private final String nickname;
+
+        private final LocalDate birth;
+
+        @TextLength(max = 50)
+        private final String email;
+
+        private final Carrier carrier;
+
+        @TextLength(max = 15)
+        private final String phone;
+
+        @TextLength(max = 100)
+        private final String password;
+
+        @TextLength(max = 100)
+        private final String pwCheck;
+
+        private final Boolean personalInfo;
+
+        private final Boolean idInfo;
+    }
 
     @Getter
     @Setter

--- a/src/main/java/com/example/spot/web/dto/token/TokenResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/token/TokenResponseDTO.java
@@ -1,11 +1,16 @@
 package com.example.spot.web.dto.token;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 public class TokenResponseDTO {
+
+    @Getter
+    @RequiredArgsConstructor
+    @Builder
+    public static class TempTokenDTO {
+        private final String tempToken;
+        private final Long tempTokenExpiresIn;
+    }
 
     @Builder
     @Getter


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 
- #201 

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.

일반 회원가입은 총 3단계에 걸쳐 이루어집니다.

1. 인증번호 전송 : 문자로 인증번호를 전송합니다.
2. 전화번호 인증 : 인증번호를 확인하고, 만약 인증번호가 일치하는 경우 임시 토큰을 발급합니다.
3. 회원가입 : 임시 토큰을 Authorization 헤더에 삽입한 후 형식에 맞춰 요청을 전송하면 DB에 회원 정보가 저장됩니다.

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
