### PR TITLE
[HOTFIX] 소셜 로그인 및 테스트 회원 생성 시, 닉네임도 처리 하도록 수정

### DIFF
--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -573,6 +573,7 @@ public class MemberServiceImpl implements MemberService {
                 .name(memberInfoListDTO.getName())
                 .carrier(memberInfoListDTO.getCarrier())
                 .birth(memberInfoListDTO.getBirth())
+                .nickname(memberInfoListDTO.getNickname())
                 .email(memberInfoListDTO.getEmail())
                 .password(UUID.randomUUID().toString())
                 .phone(memberInfoListDTO.getPhone())

--- a/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
@@ -89,6 +89,7 @@ public class MemberRequestDTO {
     public static class MemberInfoListDTO{
 
         private String name;
+        private String nickname;
         private Gender gender;
         private String email;
         private LocalDate birth;

--- a/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
+++ b/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
@@ -50,6 +50,7 @@ public class KaKaoUser {
     public Member toMember(){
         return Member.builder()
             .name(properties.getNickname())
+            .nickname(properties.getNickname())
             .email(kakao_account.getEmail())
             .profileImage(properties.getProfile_image())
             .carrier(Carrier.NONE)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#222 

<br/>

## 🔎 작업 내용

1. 소셜 로그인 및 테스트 회원 생성 시, 닉네임도 처리 하도록 수정
