### PR TITLE
[FEAT] 인기 검색어 조회 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'io.lettuce:lettuce-core:6.1.5.RELEASE'
 }
 
 sentry {

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 
     // prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core:6.1.5.RELEASE'
 }
 
 sentry {

--- a/src/main/java/com/example/SpotApplication.java
+++ b/src/main/java/com/example/SpotApplication.java
@@ -2,10 +2,12 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class SpotApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/SpotApplication.java
+++ b/src/main/java/com/example/SpotApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableCaching
+@EnableScheduling
 public class SpotApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -120,6 +120,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _STUDY_NOT_PARTICIPATED(HttpStatus.NOT_FOUND, "STUDY6016", "참가하는 스터디가 없습니다."),
     _STUDY_NOT_APPLIED(HttpStatus.NOT_FOUND, "STUDY6017", "신청한 스터디가 없습니다."),
     _RECRUITING_STUDY_IS_NOT_EXIST(HttpStatus.NOT_FOUND, "STUDY6018", "현재 회원이 모집중인 스터디가 없습니다."),
+    _HOT_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "STUDY6019", "인기 키워드가 없습니다."),
 
     // 스터디 출석 관련 에러
     _STUDY_QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "QUIZ4001", "출석 퀴즈를 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
@@ -64,6 +64,7 @@ public enum SuccessStatus implements BaseCode {
     _STUDY_APPLICANT_FOUND(HttpStatus.OK, "STUDY4010", "스터디 신청자 조회 완료"),
     _STUDY_APPLICANT_UPDATED(HttpStatus.OK, "STUDY4011", "스터디 신청 처리 완료"),
     _STUDY_APPLY_COMPLETED(HttpStatus.OK, "STUDY4012", "스터디 신청 완료"),
+    _HOT_KEYWORD_FOUND(HttpStatus.OK, "SEARCH2001", "인기 검색어 조회 완료"),
 
     //스터디 출석 퀴즈 관련
     _STUDY_QUIZ_CREATED(HttpStatus.CREATED, "QUIZ2001", "스터디 퀴즈 생성 완료"),

--- a/src/main/java/com/example/spot/config/RedisConfig.java
+++ b/src/main/java/com/example/spot/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.example.spot.config;
+
+import com.querydsl.core.annotations.Config;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig extends CachingConfigurerSupport {
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    /**
+     * yml 파일에 설정한 host와 port를 이용하여 RedisConnectionFactory를 생성한다.
+     * @return LettuceConnectionFactory
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/spot/config/RedisConfig.java
+++ b/src/main/java/com/example/spot/config/RedisConfig.java
@@ -8,7 +8,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -28,6 +30,33 @@ public class RedisConfig extends CachingConfigurerSupport {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    /**
+     * Redis 데이터 처리를 위한 템플릿을 구성합니다.
+     *  RedisTemplate을 통해서 데이터를 읽고 쓸 때 Java 객체와 Redis의 문자열 형식 간의 변환을 수행합니다.
+     * Java와 Redis 간의 데이터 포맷 차이를 신경 쓰지 않고 편리하게 데이터 통신을 할 수 있습니다.
+     * @return RedisTemplate<String, Object>
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        // Redis를 연결합니다.
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key-Value 형태로 직렬화를 수행합니다.
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash Key-Value 형태로 직렬화를 수행합니다.
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 기본적으로 직렬화를 수행합니다.
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
     }
 
 

--- a/src/main/java/com/example/spot/scheduler/HotKeywordScheduler.java
+++ b/src/main/java/com/example/spot/scheduler/HotKeywordScheduler.java
@@ -1,6 +1,8 @@
 package com.example.spot.scheduler;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,9 +45,11 @@ public class HotKeywordScheduler {
             for (TypedTuple<String> tuple : typedTuples)
                 zSetOperations.add(HOT_KEYWORD, tuple.getValue(), tuple.getScore());
 
+            String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
             // 인기 검색어 업데이트 시점 저장
-            redisTemplate.opsForValue().set(LAST_UPDATED, LocalDateTime.now().toString());
-            log.info("Hot keywords updated at {}", LocalDateTime.now());
+            redisTemplate.opsForValue().set(LAST_UPDATED, now);
+            log.info("Hot keywords updated at {}", now);
 
         }
     }

--- a/src/main/java/com/example/spot/scheduler/HotKeywordScheduler.java
+++ b/src/main/java/com/example/spot/scheduler/HotKeywordScheduler.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
@@ -19,9 +20,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class HotKeywordScheduler {
 
-    private static final String KEYWORD = "keywords";
-    private static final String HOT_KEYWORD = "hotKeywords";
-    private static final String LAST_UPDATED = "hotKeywordLastUpdated";
+    @Value("${study.keyword}")
+    private String KEYWORD;
+    @Value("${study.hot-keyword}")
+    private String HOT_KEYWORD;
+    @Value("${study.last-updated}")
+    private String LAST_UPDATED;
 
     private RedisTemplate<String, String> redisTemplate;
 

--- a/src/main/java/com/example/spot/scheduler/HotKeywordScheduler.java
+++ b/src/main/java/com/example/spot/scheduler/HotKeywordScheduler.java
@@ -30,7 +30,7 @@ public class HotKeywordScheduler {
         this.redisTemplate = redisTemplate;
     }
 
-    // 13시와 18시에 인기 검색어 업데이트
+    // 13시와 18시에 인기 검색어 목록을 업데이트 합니다.
     @Scheduled(cron = "0 0 13,18 * * *")
     public void updateHotKeywords() {
         ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
@@ -50,7 +50,6 @@ public class HotKeywordScheduler {
             // 인기 검색어 업데이트 시점 저장
             redisTemplate.opsForValue().set(LAST_UPDATED, now);
             log.info("Hot keywords updated at {}", now);
-
         }
     }
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandService.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandService.java
@@ -13,4 +13,6 @@ public interface StudyCommandService {
     StudyRegisterResponseDTO.RegisterDTO registerStudy(Long memberId, StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO);
 
     StudyLikeResponseDTO likeStudy(Long memberId, Long studyId);
+
+    String addHotKeyword(String keyword);
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandService.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandService.java
@@ -14,5 +14,5 @@ public interface StudyCommandService {
 
     StudyLikeResponseDTO likeStudy(Long memberId, Long studyId);
 
-    String addHotKeyword(String keyword);
+    void addHotKeyword(String keyword);
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -229,12 +229,9 @@ public class StudyCommandServiceImpl implements StudyCommandService {
     }
 
     /* ---------------------------------- 인기 검색어 --------------------------------------------- */
-
-
     @Override
     public String addHotKeyword(String keyword) {
         Double score = redisTemplate.opsForZSet().incrementScore("hotKeyword", keyword, 1);
         return score.toString();
     }
-
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -21,6 +21,7 @@ import com.example.spot.web.dto.study.response.StudyJoinResponseDTO;
 import com.example.spot.web.dto.study.response.StudyLikeResponseDTO;
 import com.example.spot.web.dto.study.response.StudyRegisterResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@Slf4j
 @Transactional
 @RequiredArgsConstructor
 public class StudyCommandServiceImpl implements StudyCommandService {
@@ -230,8 +232,8 @@ public class StudyCommandServiceImpl implements StudyCommandService {
 
     /* ---------------------------------- 인기 검색어 --------------------------------------------- */
     @Override
-    public String addHotKeyword(String keyword) {
+    public void addHotKeyword(String keyword) {
         Double score = redisTemplate.opsForZSet().incrementScore("hotKeyword", keyword, 1);
-        return score.toString();
+        log.info("keyword: {}, score: {}", keyword, score);
     }
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -233,9 +233,13 @@ public class StudyCommandServiceImpl implements StudyCommandService {
     }
 
     /* ---------------------------------- 인기 검색어 --------------------------------------------- */
+
+    /**
+     * 검색어를 인기 검색어(Redis)에 추가합니다. 이미 존재하는 검색어라면 score를 1 증가시킵니다.
+     * @param keyword 검색어
+     */
     @Override
     public void addHotKeyword(String keyword) {
-        Double score = redisTemplate.opsForZSet().incrementScore(KEYWORD, keyword, 1);
-        log.info("keyword: {}, score: {}", keyword, score);
+       redisTemplate.opsForZSet().incrementScore(KEYWORD, keyword, 1);
     }
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -22,6 +22,7 @@ import com.example.spot.web.dto.study.response.StudyLikeResponseDTO;
 import com.example.spot.web.dto.study.response.StudyRegisterResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +35,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StudyCommandServiceImpl implements StudyCommandService {
 
-    private static final String KEYWORD = "keywords";
+
+    @Value("${study.keyword}")
+    private String KEYWORD;
 
     private final MemberRepository memberRepository;
     private final StudyRepository studyRepository;

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -34,6 +34,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StudyCommandServiceImpl implements StudyCommandService {
 
+    private static final String KEYWORD = "keywords";
+
     private final MemberRepository memberRepository;
     private final StudyRepository studyRepository;
     private final RegionRepository regionRepository;
@@ -233,7 +235,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
     /* ---------------------------------- 인기 검색어 --------------------------------------------- */
     @Override
     public void addHotKeyword(String keyword) {
-        Double score = redisTemplate.opsForZSet().incrementScore("hotKeyword", keyword, 1);
+        Double score = redisTemplate.opsForZSet().incrementScore(KEYWORD, keyword, 1);
         log.info("keyword: {}, score: {}", keyword, score);
     }
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -21,6 +21,7 @@ import com.example.spot.web.dto.study.response.StudyJoinResponseDTO;
 import com.example.spot.web.dto.study.response.StudyLikeResponseDTO;
 import com.example.spot.web.dto.study.response.StudyRegisterResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,8 @@ public class StudyCommandServiceImpl implements StudyCommandService {
     private final RegionStudyRepository regionStudyRepository;
     private final StudyThemeRepository studyThemeRepository;
     private final PreferredStudyRepository preferredStudyRepository;
+
+    private final RedisTemplate<String, String> redisTemplate;
 
     /* ----------------------------- 스터디 생성/참여 관련 API ------------------------------------- */
 
@@ -163,6 +166,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
         return new StudyLikeResponseDTO(preferredStudy);
     }
 
+
     private void createMemberStudy(Member member, Study study) {
 
         MemberStudy memberStudy = MemberStudy.builder()
@@ -223,4 +227,14 @@ public class StudyCommandServiceImpl implements StudyCommandService {
                     study.addStudyTheme(studyTheme);
                 });
     }
+
+    /* ---------------------------------- 인기 검색어 --------------------------------------------- */
+
+
+    @Override
+    public String addHotKeyword(String keyword) {
+        Double score = redisTemplate.opsForZSet().incrementScore("hotKeyword", keyword, 1);
+        return score.toString();
+    }
+
 }

--- a/src/main/java/com/example/spot/service/study/StudyQueryService.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryService.java
@@ -3,6 +3,7 @@ package com.example.spot.service.study;
 import com.example.spot.domain.enums.StudySortBy;
 import com.example.spot.domain.enums.ThemeType;
 import com.example.spot.web.dto.search.SearchRequestDTO.SearchRequestStudyDTO;
+import com.example.spot.web.dto.search.SearchResponseDTO.HotKeywordDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.StudyPreviewDTO;
 import com.example.spot.web.dto.study.response.StudyInfoResponseDTO;
@@ -12,6 +13,9 @@ import com.example.spot.web.dto.study.response.StudyScheduleResponseDTO;
 import org.springframework.data.domain.Pageable;
 
 public interface StudyQueryService {
+
+    // 인기 검색어 조회
+    HotKeywordDTO getHotKeyword();
 
     // 스터디 정보 조회
     StudyInfoResponseDTO.StudyInfoDTO getStudyInfo(Long studyId);

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -45,6 +45,7 @@ import com.example.spot.web.dto.study.response.StudyMemberResponseDTO.StudyMembe
 import com.example.spot.web.dto.study.response.StudyPostResponseDTO;
 import com.example.spot.web.dto.study.response.StudyScheduleResponseDTO;
 import com.example.spot.web.dto.study.response.StudyScheduleResponseDTO.StudyScheduleDTO;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -117,8 +118,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
         }
 
         // 마지막 업데이트 시간 가져오기
-        LocalDateTime updatedAt = LocalDateTime.parse(
-            redisTemplate.opsForValue().get(LAST_UPDATED));
+        String updatedAt = redisTemplate.opsForValue().get(LAST_UPDATED);
 
         return HotKeywordDTO.builder()
             .keyword(keywordDTOS)

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -57,6 +57,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -74,8 +75,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudyQueryServiceImpl implements StudyQueryService {
 
 
-    private static final String HOT_KEYWORD = "hotKeywords";
-    private static final String LAST_UPDATED = "hotKeywordLastUpdated";
+    @Value("${study.hot-keyword}")
+    private String HOT_KEYWORD;
+    @Value("${study.last-updated}")
+    private String LAST_UPDATED;
 
     private final MemberRepository memberRepository;
 

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -45,6 +45,7 @@ import com.example.spot.web.dto.study.response.StudyMemberResponseDTO.StudyMembe
 import com.example.spot.web.dto.study.response.StudyPostResponseDTO;
 import com.example.spot.web.dto.study.response.StudyScheduleResponseDTO;
 import com.example.spot.web.dto.study.response.StudyScheduleResponseDTO.StudyScheduleDTO;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -114,7 +115,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
         return HotKeywordDTO.builder()
             .keyword(keywordDTOS)
-            .count(zSetOperations.size(KEYWORD))
+            .updatedAt(LocalDateTime.now())
             .build();
     }
 

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -95,6 +95,11 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
     private final RedisTemplate<String, String> redisTemplate;
 
+    /**
+     * 인기 검색어를 조회하는 메서드입니다. 인기 검색어는 매일 13시, 18시에 총 2번 업데이트 됩니다.
+     * 인기 검색어는 검색된 횟수 순으로 5개까지 조회 가능합니다.
+     * @return 인기 검색어 목록 및 업데이트 시간을 반환합니다.
+     */
     @Override
     public HotKeywordDTO getHotKeyword() {
         // popular_keywords에서 캐시된 검색어 목록 가져오기

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -344,6 +344,8 @@ public class SearchController {
         @RequestParam StudySortBy sortBy) {
         // 메소드 구현
         StudyPreviewDTO studies = studyQueryService.findStudiesByKeyword(PageRequest.of(page, size), keyword, sortBy);
+        // 검색 키워드 저장
+        studyCommandService.addHotKeyword(keyword);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
     }
 
@@ -356,15 +358,6 @@ public class SearchController {
             """)
     public ApiResponse<HotKeywordDTO> getHotKeywords() {
         return ApiResponse.onSuccess(SuccessStatus._HOT_KEYWORD_FOUND, studyQueryService.getHotKeyword());
-    }
-    @Tag(name = "스터디 검색")
-    @GetMapping("/search/studies/hot-keywords")
-    @Operation(summary = "[스터디 검색] 인기 검색어 추가",
-        description = """
-            ## [스터디 검색] 검색어를 추가합니다. 
-            """)
-    public ApiResponse<String> setHotKeywords(@RequestParam String keyword) {
-        return ApiResponse.onSuccess(SuccessStatus._HOT_KEYWORD_FOUND, studyCommandService.addHotKeyword(keyword));
     }
 
 

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -37,22 +37,6 @@ public class SearchController {
 
     private final StudyQueryService studyQueryService;
 
-    /* ----------------------------- 인기 검색어 조회 ------------------------------------- */
-    @Tag(name = "검색 화면 ", description = "검색 화면 API")
-    @GetMapping("/search/studies/recommend/main/members/{memberId}")
-    @Operation(summary = "[메인 화면] 회원 별 추천 스터디 3개 조회",
-        description = """
-            ## [메인 화면] 접속한 회원의 추천 스터디 3개를 조회 합니다.
-            조회된 스터디 3개의 정보가 반환 됩니다.""",
-        security = @SecurityRequirement(name = "accessToken"))
-    @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
-    public ApiResponse<StudyPreviewDTO> recommendStudiesForMain(@PathVariable @ExistMember long memberId) {
-        SecurityUtils.verifyUserId(memberId);
-        StudyPreviewDTO recommendStudies = studyQueryService.findRecommendStudies(memberId);
-        return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, recommendStudies);
-    }
-
-
 
     /* ----------------------------- 메인 화면 ------------------------------------- */
 

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -1,15 +1,13 @@
 package com.example.spot.web.controller;
 
 import com.example.spot.api.ApiResponse;
-import com.example.spot.api.code.status.ErrorStatus;
 import com.example.spot.api.code.status.SuccessStatus;
-import com.example.spot.api.exception.GeneralException;
 import com.example.spot.domain.enums.StudySortBy;
 import com.example.spot.domain.enums.ThemeType;
 import com.example.spot.security.utils.SecurityUtils;
+import com.example.spot.service.study.StudyCommandService;
 import com.example.spot.service.study.StudyQueryService;
 import com.example.spot.validation.annotation.ExistMember;
-import com.example.spot.validation.validator.MemberValidator;
 import com.example.spot.web.dto.search.SearchRequestDTO.SearchRequestStudyDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.HotKeywordDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
@@ -20,12 +18,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class SearchController {
 
     private final StudyQueryService studyQueryService;
+    private final StudyCommandService studyCommandService;
 
 
     /* ----------------------------- 메인 화면 ------------------------------------- */
@@ -352,15 +348,25 @@ public class SearchController {
     }
 
     @Tag(name = "스터디 검색")
-    @GetMapping("/search/studies/hot-keywords")
+    @GetMapping("/search/studies/set/hot-keywords")
     @Operation(summary = "[스터디 검색] 인기 검색어 조회",
         description = """
             ## [스터디 검색] 현재 스터디 검색에 가장 많이 검색된 검색어를 조회합니다.
             인기 검색어는 13시, 18시에 초기화 됩니다. 초기화 된 시간과 현재 인기 검색어 목록을 반환합니다.
             """)
     public ApiResponse<HotKeywordDTO> getHotKeywords() {
-        return null;
+        return ApiResponse.onSuccess(SuccessStatus._HOT_KEYWORD_FOUND, studyQueryService.getHotKeyword());
     }
+    @Tag(name = "스터디 검색")
+    @GetMapping("/search/studies/hot-keywords")
+    @Operation(summary = "[스터디 검색] 인기 검색어 추가",
+        description = """
+            ## [스터디 검색] 검색어를 추가합니다. 
+            """)
+    public ApiResponse<String> setHotKeywords(@RequestParam String keyword) {
+        return ApiResponse.onSuccess(SuccessStatus._HOT_KEYWORD_FOUND, studyCommandService.addHotKeyword(keyword));
+    }
+
 
     /* ----------------------------- 테마 별 스터디 검색  ------------------------------------- */
     @Tag(name = "스터디 검색")

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -37,6 +37,25 @@ public class SearchController {
 
     private final StudyQueryService studyQueryService;
 
+    /* ----------------------------- 인기 검색어 조회 ------------------------------------- */
+    @Tag(name = "검색 화면 ", description = "검색 화면 API")
+    @GetMapping("/search/studies/recommend/main/members/{memberId}")
+    @Operation(summary = "[메인 화면] 회원 별 추천 스터디 3개 조회",
+        description = """
+            ## [메인 화면] 접속한 회원의 추천 스터디 3개를 조회 합니다.
+            조회된 스터디 3개의 정보가 반환 됩니다.""",
+        security = @SecurityRequirement(name = "accessToken"))
+    @Parameter(name = "memberId", description = "조회할 유저의 ID를 입력 받습니다.", required = true)
+    public ApiResponse<StudyPreviewDTO> recommendStudiesForMain(@PathVariable @ExistMember long memberId) {
+        SecurityUtils.verifyUserId(memberId);
+        StudyPreviewDTO recommendStudies = studyQueryService.findRecommendStudies(memberId);
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, recommendStudies);
+    }
+
+
+
+    /* ----------------------------- 메인 화면 ------------------------------------- */
+
     @Tag(name = "메인 화면", description = "메인 화면 API")
     @GetMapping("/search/studies/recommend/main/members/{memberId}")
     @Operation(summary = "[메인 화면] 회원 별 추천 스터디 3개 조회",
@@ -345,6 +364,17 @@ public class SearchController {
         // 메소드 구현
         StudyPreviewDTO studies = studyQueryService.findStudiesByKeyword(PageRequest.of(page, size), keyword, sortBy);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
+    }
+
+    @Tag(name = "스터디 검색")
+    @GetMapping("/search/studies/hot-keyword")
+    @Operation(summary = "[스터디 검색] 인기 검색어 조회",
+        description = """
+            ## [스터디 검색] 현재 스터디 검색에 가장 많이 검색된 검색어를 조회합니다.
+            인기 검색어는 13시, 18시에 초기화 됩니다. 초기화 된 시간과 현재 인기 검색어 목록을 반환합니다.
+            """)
+    public ApiResponse<String> recommendStudiesForMain() {
+        return null;
     }
 
     /* ----------------------------- 테마 별 스터디 검색  ------------------------------------- */

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -352,13 +352,13 @@ public class SearchController {
     }
 
     @Tag(name = "스터디 검색")
-    @GetMapping("/search/studies/hot-keyword")
+    @GetMapping("/search/studies/hot-keywords")
     @Operation(summary = "[스터디 검색] 인기 검색어 조회",
         description = """
             ## [스터디 검색] 현재 스터디 검색에 가장 많이 검색된 검색어를 조회합니다.
             인기 검색어는 13시, 18시에 초기화 됩니다. 초기화 된 시간과 현재 인기 검색어 목록을 반환합니다.
             """)
-    public ApiResponse<HotKeywordDTO> recommendStudiesForMain() {
+    public ApiResponse<HotKeywordDTO> getHotKeywords() {
         return null;
     }
 

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -350,7 +350,7 @@ public class SearchController {
     }
 
     @Tag(name = "스터디 검색")
-    @GetMapping("/search/studies/set/hot-keywords")
+    @GetMapping("/search/studies/hot-keywords")
     @Operation(summary = "[스터디 검색] 인기 검색어 조회",
         description = """
             ## [스터디 검색] 현재 스터디 검색에 가장 많이 검색된 검색어를 조회합니다.

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -344,7 +344,9 @@ public class SearchController {
         @RequestParam StudySortBy sortBy) {
         // 메소드 구현
         StudyPreviewDTO studies = studyQueryService.findStudiesByKeyword(PageRequest.of(page, size), keyword, sortBy);
-        // 검색 키워드 저장
+
+        // 검색 키워드 저장 -> 검색이 성공적으로 이루어졌을 때만 저장.
+        // 만약 키워드 검색 결과가 존재하지 않으면 저장하지 않음.
         studyCommandService.addHotKeyword(keyword);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
     }

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -11,6 +11,7 @@ import com.example.spot.service.study.StudyQueryService;
 import com.example.spot.validation.annotation.ExistMember;
 import com.example.spot.validation.validator.MemberValidator;
 import com.example.spot.web.dto.search.SearchRequestDTO.SearchRequestStudyDTO;
+import com.example.spot.web.dto.search.SearchResponseDTO.HotKeywordDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.StudyPreviewDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -357,7 +358,7 @@ public class SearchController {
             ## [스터디 검색] 현재 스터디 검색에 가장 많이 검색된 검색어를 조회합니다.
             인기 검색어는 13시, 18시에 초기화 됩니다. 초기화 된 시간과 현재 인기 검색어 목록을 반환합니다.
             """)
-    public ApiResponse<String> recommendStudiesForMain() {
+    public ApiResponse<HotKeywordDTO> recommendStudiesForMain() {
         return null;
     }
 

--- a/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
@@ -10,6 +10,7 @@ import com.example.spot.domain.mapping.PreferredStudy;
 import com.example.spot.domain.mapping.RegionStudy;
 import com.example.spot.domain.mapping.StudyTheme;
 import com.example.spot.domain.study.Study;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -27,7 +28,7 @@ public class SearchResponseDTO {
     @AllArgsConstructor
     public static class HotKeywordDTO {
         Set<KeywordDTO> keyword;
-        LocalDateTime updatedAt;
+        String updatedAt;
 
         @Builder
         @Getter

--- a/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
@@ -12,6 +12,7 @@ import com.example.spot.domain.mapping.StudyTheme;
 import com.example.spot.domain.study.Study;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +26,7 @@ public class SearchResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class HotKeywordDTO {
-        List<String> keyword;
+        Set<String> keyword;
         Long count;
     }
 

--- a/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
@@ -27,7 +27,7 @@ public class SearchResponseDTO {
     @AllArgsConstructor
     public static class HotKeywordDTO {
         Set<KeywordDTO> keyword;
-        Long count;
+        LocalDateTime updatedAt;
 
         @Builder
         @Getter

--- a/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
@@ -26,8 +26,17 @@ public class SearchResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class HotKeywordDTO {
-        Set<String> keyword;
+        Set<KeywordDTO> keyword;
         Long count;
+
+        @Builder
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class KeywordDTO{
+            String keyword;
+            Double point;
+        }
     }
 
     @Builder

--- a/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/SearchResponseDTO.java
@@ -19,6 +19,16 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 public class SearchResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HotKeywordDTO {
+        List<String> keyword;
+        Long count;
+    }
+
     @Builder
     @Getter
     @NoArgsConstructor


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#217 

<br/>

## 🔎 작업 내용
1. Redis 도입 
2. 스터디 검색 시, Redis 상의 검색 키워드에 해당하는 Count 값이 증가 함
3. 매일 13시, 18시에 Count 값 기준으로 인기 검색어 갱신 (스케줄러 사용) 

--- 
아래 링크 통해서 Redis 설치한 뒤, application.yml 파일에 해당 기능과 관련된 값 추가 해야 정상적으로 코드가 실행 됩니다.  Slack에 추가할 내용 공유 하겠습니다. 

https://wlswoo.tistory.com/44

<br/>
