### PR TITLE
[FIX] 전화번호 랜덤 생성되게 하여 중복 방지

### DIFF
--- a/src/main/java/com/example/spot/security/utils/MemberUtils.java
+++ b/src/main/java/com/example/spot/security/utils/MemberUtils.java
@@ -1,0 +1,30 @@
+package com.example.spot.security.utils;
+
+import java.util.Random;
+
+public class MemberUtils {
+
+    /**
+     * 랜덤한 휴대전화 번호를 생성합니다.
+     * @return 랜덤한 휴대전화 번호
+     */
+    public static String generatePhoneNumber() {
+        Random random = new Random();
+
+        // 010으로 시작하는 한국의 일반적인 휴대전화 번호 형식
+        StringBuilder phoneNumber = new StringBuilder("010-");
+
+        // 4자리 숫자 생성
+        for (int i = 0; i < 4; i++)
+            phoneNumber.append(random.nextInt(10)); // 0부터 9까지의 숫자 중 랜덤 선택
+
+        phoneNumber.append("-");
+
+        // 4자리 숫자 생성
+        for (int i = 0; i < 4; i++)
+            phoneNumber.append(random.nextInt(10)); // 0부터 9까지의 숫자 중 랜덤 선택
+
+        return phoneNumber.toString();
+    }
+
+}

--- a/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
+++ b/src/main/java/com/example/spot/web/dto/member/kakao/KaKaoUser.java
@@ -3,6 +3,7 @@ package com.example.spot.web.dto.member.kakao;
 import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.Carrier;
 import com.example.spot.domain.enums.LoginType;
+import com.example.spot.security.utils.MemberUtils;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -55,7 +56,7 @@ public class KaKaoUser {
             .profileImage(properties.getProfile_image())
             .carrier(Carrier.NONE)
             .password("default")
-            .phone("NONE")
+            .phone(MemberUtils.generatePhoneNumber())
             .birth(LocalDate.now())
             .personalInfo(false)
             .idInfo(false)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #235 

<br/>

## 🔎 작업 내용

1. 전화번호 랜덤 생성 유틸 메서드를 통해 카카오 로그인 시 전화 번호 중복 방지

