### PR TITLE
[MODIFY] 출석 퀴즈에 일정 연결

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -133,8 +133,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _STUDY_QUIZ_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "QUIZ4003", "금일 출석 퀴즈가 이미 존재합니다."),
     _STUDY_QUIZ_ID_NULL(HttpStatus.BAD_REQUEST, "QUIZ4004", "출석 퀴즈 아이디가 입력되지 않았습니다."),
     _STUDY_QUIZ_CREATION_INVALID(HttpStatus.FORBIDDEN, "QUIZ4005", "출석 퀴즈는 스터디장만 생성할 수 있습니다."),
-    _STUDY_ATTENDANCE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "QUIZ4004", "이미 출석 체크되었습니다."),
-    _STUDY_ATTENDANCE_ATTEMPT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "QUIZ4005", "출석 퀴즈 시도 횟수가 초과되었습니다."),
+    _STUDY_ATTENDANCE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "QUIZ4006", "이미 출석 체크되었습니다."),
+    _STUDY_ATTENDANCE_ATTEMPT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "QUIZ4007", "출석 퀴즈 시도 횟수가 초과되었습니다."),
+    _STUDY_QUIZ_DELETION_INVALID(HttpStatus.BAD_REQUEST, "QUIZ4008", "출석 퀴즈는 스터디장만 삭제할 수 있습니다."),
 
     // S3 관련 에러
     _FILE_IS_NULL(HttpStatus.BAD_REQUEST, "S34001", "파일이 입력되지 않았습니다."),

--- a/src/main/java/com/example/spot/domain/Quiz.java
+++ b/src/main/java/com/example/spot/domain/Quiz.java
@@ -2,22 +2,27 @@ package com.example.spot.domain;
 
 import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.mapping.MemberAttendance;
+import com.example.spot.domain.study.Schedule;
 import com.example.spot.domain.study.Study;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @DynamicUpdate
 @DynamicInsert
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Quiz extends BaseEntity {
+public class Quiz {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,11 +39,11 @@ public class Quiz extends BaseEntity {
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
     private List<MemberAttendance> memberAttendanceList;
 
-    //== 해당 퀴즈를 생성한 스터디 ==//
+    //== 해당 퀴즈를 생성한 일정 ==//
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "study_id", nullable = false)
-    private Study study;
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private Schedule schedule;
 
     //== 퀴즈 생성자 ==//
     @Setter
@@ -46,14 +51,22 @@ public class Quiz extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Column
+    private LocalDateTime createdAt;
+
+    @Column
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
 /* ----------------------------- 생성자 ------------------------------------- */
 
     @Builder
-    public Quiz(Study study, Member member, String question, String answer) {
-        this.study = study;
+    public Quiz(Schedule schedule, Member member, String question, String answer, LocalDateTime createdAt) {
+        this.schedule = schedule;
         this.member = member;
         this.question = question;
         this.answer = answer;
+        this.createdAt = createdAt;
         this.memberAttendanceList = new ArrayList<>();
     }
 

--- a/src/main/java/com/example/spot/domain/study/Schedule.java
+++ b/src/main/java/com/example/spot/domain/study/Schedule.java
@@ -1,11 +1,14 @@
 package com.example.spot.domain.study;
 import com.example.spot.domain.Member;
+import com.example.spot.domain.Quiz;
 import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.enums.Period;
 import com.example.spot.web.dto.memberstudy.request.ScheduleRequestDTO;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -32,6 +35,9 @@ public class Schedule extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL)
+    private List<Quiz> quizList = new ArrayList<>();
 
     @Column(nullable = false, length = 20)
     private String title;
@@ -66,10 +72,16 @@ public class Schedule extends BaseEntity {
         this.finishedAt = finishedAt;
         this.isAllDay = isAllDay;
         this.period = period;
+        this.quizList = new ArrayList<>();
     }
 
 /* ----------------------------- 메소드 ------------------------------------- */
 
+
+    public void addQuiz(Quiz quiz) {
+        quizList.add(quiz);
+        quiz.setSchedule(this);
+    }
     public void modSchedule(ScheduleRequestDTO.ScheduleDTO scheduleDTO) {
         this.title = scheduleDTO.getTitle();
         this.location = scheduleDTO.getLocation();

--- a/src/main/java/com/example/spot/domain/study/Study.java
+++ b/src/main/java/com/example/spot/domain/study/Study.java
@@ -107,9 +107,6 @@ public class Study extends BaseEntity {
     private List<PreferredStudy> preferredStudies = new ArrayList<>();
 
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
-    private List<Quiz> quizzes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
     private List<StudyPost> studyPosts = new ArrayList<>();
 
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
@@ -148,7 +145,6 @@ public class Study extends BaseEntity {
         this.preferredStudies = new ArrayList<>();
         this.memberStudies = new ArrayList<>();
         this.regionStudies = new ArrayList<>();
-        this.quizzes = new ArrayList<>();
         this.studyPosts = new ArrayList<>();
         this.toDoLists = new ArrayList<>();
         this.notifications = new ArrayList<>();
@@ -190,11 +186,6 @@ public class Study extends BaseEntity {
 
     public void updateSchedule(Schedule schedule) {
         schedules.set(schedules.indexOf(schedule), schedule);
-    }
-
-    public void addQuiz(Quiz quiz) {
-        quizzes.add(quiz);
-        quiz.setStudy(this);
     }
 
     public void addStudyPost(StudyPost studyPost) {

--- a/src/main/java/com/example/spot/repository/QuizRepository.java
+++ b/src/main/java/com/example/spot/repository/QuizRepository.java
@@ -13,9 +13,7 @@ import java.util.Optional;
 @Repository
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
-    Optional<Quiz> findByIdAndStudyId(Long id, Long studyId);
+    List<Quiz> findByScheduleId(Long scheduleId);
 
-    @Query("SELECT q FROM Quiz q WHERE q.study.id = :studyId AND q.createdAt >= :startOfDay AND q.createdAt <= :endOfDay")
-    List<Quiz> findAllByStudyIdAndCreatedAtBetween(@Param("studyId") Long studyId, @Param("startOfDay") LocalDateTime startOfDay, @Param("endOfDay") LocalDateTime endOfDay);
-
+    List<Quiz> findAllByScheduleIdAndCreatedAtBetween(Long scheduleId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandService.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandService.java
@@ -9,6 +9,8 @@ import com.example.spot.web.dto.memberstudy.response.*;
 import com.example.spot.web.dto.study.response.StudyApplyResponseDTO;
 import jakarta.validation.Valid;
 
+import java.time.LocalDate;
+
 public interface MemberStudyCommandService {
 
     StudyWithdrawalResponseDTO.WithdrawalDTO withdrawFromStudy(Long memberId, Long studyId);
@@ -27,13 +29,13 @@ public interface MemberStudyCommandService {
     ScheduleResponseDTO.ScheduleDTO modSchedule(Long studyId, Long scheduleId, ScheduleRequestDTO.ScheduleDTO scheduleModDTO);
 
     // 스터디 퀴즈 생성
-    StudyQuizResponseDTO.QuizDTO createAttendanceQuiz(Long studyId, StudyQuizRequestDTO.QuizDTO quizRequestDTO);
+    StudyQuizResponseDTO.QuizDTO createAttendanceQuiz(Long studyId, Long scheduleId, StudyQuizRequestDTO.QuizDTO quizRequestDTO);
 
     // 스터디 출석
-    StudyQuizResponseDTO.AttendanceDTO attendantStudy(Long studyId, Long quizId, StudyQuizRequestDTO.AttendanceDTO attendanceRequestDTO);
+    StudyQuizResponseDTO.AttendanceDTO attendantStudy(Long studyId, Long scheduleId, StudyQuizRequestDTO.AttendanceDTO attendanceRequestDTO);
 
     // 스터디 퀴즈 삭제
-    StudyQuizResponseDTO.QuizDTO deleteAttendanceQuiz(Long studyId, Long quizId);
+    StudyQuizResponseDTO.QuizDTO deleteAttendanceQuiz(Long studyId, Long scheduleId, LocalDate date);
 
     // 스터디 투표 생성
     StudyVoteResponseDTO.VotePreviewDTO createVote(Long studyId, StudyVoteRequestDTO.VoteDTO voteDTO);

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryService.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyQueryService.java
@@ -35,10 +35,10 @@ public interface MemberStudyQueryService {
     StudyApplicantDTO isApplied(Long studyId);
 
     // 금일 회원 출석 여부 불러오기
-    StudyQuizResponseDTO.AttendanceListDTO getAllAttendances(Long studyId, Long quizId);
+    StudyQuizResponseDTO.AttendanceListDTO getAllAttendances(Long studyId, Long scheduleId, LocalDate date);
 
     // 스터디 출석퀴즈 조회
-    StudyQuizResponseDTO.QuizDTO getAttendanceQuiz(Long studyId, LocalDate date);
+    StudyQuizResponseDTO.QuizDTO getAttendanceQuiz(Long studyId, Long scheduleId, LocalDate date);
 
     // 스터디 투표 목록 조회
     StudyVoteResponseDTO.VoteListDTO getAllVotes(Long studyId);

--- a/src/main/java/com/example/spot/web/controller/MemberStudyController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberStudyController.java
@@ -422,7 +422,8 @@ public class MemberStudyController {
     @GetMapping("/studies/{studyId}/schedules/{scheduleId}/quiz")
     public ApiResponse<StudyQuizResponseDTO.QuizDTO> getAttendanceQuiz(
             @PathVariable @ExistStudy Long studyId,
-            @PathVariable @ExistSchedule Long scheduleId, LocalDate date) {
+            @PathVariable @ExistSchedule Long scheduleId,
+            @RequestParam LocalDate date) {
         StudyQuizResponseDTO.QuizDTO quizDTO = memberStudyQueryService.getAttendanceQuiz(studyId, scheduleId, date);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_QUIZ_FOUND, quizDTO);
     }
@@ -461,14 +462,15 @@ public class MemberStudyController {
     @DeleteMapping("/studies/{studyId}/schedules/{scheduleId}/quiz")
     public ApiResponse<StudyQuizResponseDTO.QuizDTO> deleteAttendanceQuiz(
             @PathVariable @ExistStudy Long studyId,
-            @PathVariable @ExistSchedule Long scheduleId, LocalDate date) {
+            @PathVariable @ExistSchedule Long scheduleId,
+            @RequestParam LocalDate date) {
         StudyQuizResponseDTO.QuizDTO quizDTO = memberStudyCommandService.deleteAttendanceQuiz(studyId, scheduleId, date);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_QUIZ_DELETED, quizDTO);
     }
 
     @Tag(name = "스터디 출석체크")
-    @Operation(summary = "[스터디 출석체크] 금일 회원 출석부 불러오기", description = """ 
-        ## [스터디 출석체크] 금일 모든 스터디 회원의 출석 여부를 불러옵니다.
+    @Operation(summary = "[스터디 출석체크] 회원 출석부 불러오기", description = """ 
+        ## [스터디 출석체크] 지정된 날짜의 모든 스터디 회원의 출석 여부를 불러옵니다.
         * 출석체크 화면에 표시되는 스터디 회원 정보(프로필 사진, 이름, 출석 여부, 스터디장 여부) 목록를 반환합니다.
         * date에는 출석 정보를 확인할 날짜를 입력합니다.
         """)
@@ -477,7 +479,8 @@ public class MemberStudyController {
     @GetMapping("/studies/{studyId}/schedules/{scheduleId}/attendance")
     public ApiResponse<StudyQuizResponseDTO.AttendanceListDTO> getAllAttendances(
             @PathVariable @ExistStudy Long studyId,
-            @PathVariable @ExistSchedule Long scheduleId, LocalDate date) {
+            @PathVariable @ExistSchedule Long scheduleId,
+            @RequestParam LocalDate date) {
         StudyQuizResponseDTO.AttendanceListDTO attendanceListDTO = memberStudyQueryService.getAllAttendances(studyId, scheduleId, date);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_MEMBER_ATTENDANCES_FOUND, attendanceListDTO);
     }

--- a/src/main/java/com/example/spot/web/dto/memberstudy/request/StudyQuizRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/request/StudyQuizRequestDTO.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class StudyQuizRequestDTO {
 
@@ -13,6 +15,8 @@ public class StudyQuizRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class QuizDTO {
+
+        private LocalDateTime createdAt;
 
         @TextLength(min = 1, max = 20)
         private String question;
@@ -25,6 +29,8 @@ public class StudyQuizRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AttendanceDTO {
+
+        private LocalDateTime dateTime;
 
         @TextLength(min = 1, max = 10)
         private String answer;

--- a/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyQuizResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyQuizResponseDTO.java
@@ -59,13 +59,13 @@ public class StudyQuizResponseDTO {
     @Builder(access = AccessLevel.PRIVATE)
     public static class AttendanceListDTO {
 
-        private final Long studyId;
+        private final Long scheduleId;
         private final Long quizId;
         private final List<StudyMemberDTO> studyMembers;
 
         public static AttendanceListDTO toDTO(Quiz quiz, List<StudyMemberDTO> studyMembers) {
             return AttendanceListDTO.builder()
-                    .studyId(quiz.getStudy().getId())
+                    .scheduleId(quiz.getSchedule().getId())
                     .quizId(quiz.getId())
                     .studyMembers(studyMembers)
                     .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 
- #255 
- SPOT-101

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.
- Quiz 도메인 수정 : createdAt을 프론트에서 받고, studyId 대신 scheduleId를 외래키로 받도록 수정했습니다
- 출석퀴즈 관련 API 전체 수정 : 현재 출석퀴즈가 일정과 연동이 되어있지 않아(스터디랑만 연동이 되어있어) 요구사항대로 API가 동작하지 않았던 것으로 확인됩니다...! 따라서 모든 출석퀴즈 API를 일정과 연동하는 방향으로 수정하였습니다.

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
