### PR TITLE
[FIX] 소셜 로그인 시, 중복 가입 되지 않도록 로직 수정 

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _NULL_VALUE(HttpStatus.BAD_REQUEST, "COMMON4011", "값이 입력되지 않았습니다."),
     _VALUE_RANGE_EXCEEDED(HttpStatus.BAD_REQUEST, "COMMON4012", "값이 지정된 범위를 초과합니다."),
     _TERMS_NOT_AGREED(HttpStatus.FORBIDDEN, "COMMON4013", "이용 약관이 동의되지 않았습니다."),
+    _MEMBER_EMAIL_EXIST(HttpStatus.BAD_REQUEST, "COMMON4014", "이미 가입 된 이메일입니다. 다른 로그인 방식을 이용해주세요."),
 
     // 네이버 소셜 로그인 관련 에러
     _NAVER_SIGN_IN_INTEGRATION_FAILED(HttpStatus.UNAUTHORIZED, "NAVER4001", "네이버 로그인 연동에 실패하였습니다."),

--- a/src/main/java/com/example/spot/domain/Member.java
+++ b/src/main/java/com/example/spot/domain/Member.java
@@ -50,7 +50,7 @@ public class Member extends BaseEntity {
     private String password;
 
     @Setter
-    @Column(nullable = false, length = 8)
+    @Column(nullable = false, length = 20)
     private String nickname;
 
     @Column(nullable = false, length = 50, unique = true)

--- a/src/main/java/com/example/spot/repository/MemberRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberRepository.java
@@ -18,6 +18,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByLoginId(String loginId);
 
+    boolean existsByEmailAndLoginTypeNot(String email, LoginType loginType);
+
     boolean existsByEmailAndLoginType(String email, LoginType loginType);
 
     Optional<Member> findByEmailAndLoginType(String email, LoginType loginType);

--- a/src/main/java/com/example/spot/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/spot/security/oauth/CustomOAuth2UserService.java
@@ -47,8 +47,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (optionalMember.isEmpty()) {
             if (provider.equals("google")) {
                 Member newMember = Member.builder()
-                        .name(attributes.get("name").toString())
-                        .nickname(attributes.get("name").toString())
+                        .name(attributes.get("name").toString().substring(0, 10))
+                        .nickname(attributes.get("name").toString().substring(0, 10))
                         .email(oauthEmail)
                         .profileImage(attributes.get("picture").toString())
                         .carrier(Carrier.NONE)
@@ -61,11 +61,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .loginType(LoginType.GOOGLE)
                         .build();
                 memberService.save(newMember);
-                return new CustomOAuth2User(newMember, attributes);
+                return new CustomOAuth2User(newMember, attributes, false);
             }
             throw new MemberHandler(ErrorStatus._MEMBER_UNSUPPORTED_LOGIN_TYPE);
         }
 
-        return new CustomOAuth2User(optionalMember.get(), attributes);
+        return new CustomOAuth2User(optionalMember.get(), attributes, true);
     }
 }

--- a/src/main/java/com/example/spot/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/spot/security/oauth/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.example.spot.security.oauth;
 
 import com.example.spot.api.code.status.ErrorStatus;
+import com.example.spot.api.exception.GeneralException;
 import com.example.spot.api.exception.handler.MemberHandler;
 import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.Carrier;
@@ -38,6 +39,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2UserInfo oAuthUserInfo = OAuthUserInfoFactory.getOAuthUserInfo(provider, attributes);
 
         String oauthEmail = oAuthUserInfo.getEmail();
+
+        if (memberRepository.existsByEmailAndLoginTypeNot(oauthEmail, LoginType.GOOGLE))
+            throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
+
         Optional<Member> optionalMember = memberRepository.findByEmail(oauthEmail);
         if (optionalMember.isEmpty()) {
             if (provider.equals("google")) {

--- a/src/main/java/com/example/spot/security/oauth/CustomOAuthSuccessHandler.java
+++ b/src/main/java/com/example/spot/security/oauth/CustomOAuthSuccessHandler.java
@@ -8,6 +8,7 @@ import com.example.spot.domain.Member;
 import com.example.spot.repository.MemberRepository;
 import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.web.dto.member.MemberResponseDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.SocialLoginSignInDTO;
 import com.example.spot.web.dto.member.google.CustomOAuth2User;
 import com.example.spot.web.dto.member.google.GoogleUserInfo;
 import com.example.spot.web.dto.token.TokenResponseDTO;
@@ -53,7 +54,9 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
                 .email(member.getEmail())
                 .build();
 
-        ApiResponse<MemberResponseDTO.MemberSignInDTO> apiResponse = ApiResponse.onSuccess(SuccessStatus._OK, memberSignInDTO);
+        ApiResponse<MemberResponseDTO.SocialLoginSignInDTO> apiResponse = ApiResponse.onSuccess(
+                SuccessStatus._OK, SocialLoginSignInDTO.toDTO(
+                        customOAuth2User.getIsSpotMember(), member.getLoginType() ,memberSignInDTO));
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/example/spot/security/oauth/CustomOAuthSuccessHandler.java
+++ b/src/main/java/com/example/spot/security/oauth/CustomOAuthSuccessHandler.java
@@ -51,12 +51,13 @@ public class CustomOAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         MemberResponseDTO.MemberSignInDTO memberSignInDTO = MemberResponseDTO.MemberSignInDTO.builder()
                 .tokens(token)
                 .memberId(member.getId())
+                .loginType(member.getLoginType())
                 .email(member.getEmail())
                 .build();
 
         ApiResponse<MemberResponseDTO.SocialLoginSignInDTO> apiResponse = ApiResponse.onSuccess(
                 SuccessStatus._OK, SocialLoginSignInDTO.toDTO(
-                        customOAuth2User.getIsSpotMember(), member.getLoginType() ,memberSignInDTO));
+                        customOAuth2User.getIsSpotMember(),memberSignInDTO));
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -2,6 +2,7 @@ package com.example.spot.service.auth;
 
 import com.example.spot.web.dto.member.MemberRequestDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.SocialLoginSignInDTO;
 import com.example.spot.web.dto.member.naver.NaverCallback;
 import com.example.spot.web.dto.token.TokenResponseDTO;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
@@ -18,7 +19,7 @@ public interface AuthService {
 
     void authorizeWithNaver(HttpServletRequest request, HttpServletResponse response);
 
-    MemberResponseDTO.NaverSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException;
+    SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException;
 
     MemberResponseDTO.MemberSignInDTO signIn(MemberRequestDTO.SignInDTO signInDTO);
 

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -169,6 +169,7 @@ public class AuthServiceImpl implements AuthService{
         MemberResponseDTO.MemberSignInDTO signInDTO = MemberResponseDTO.MemberSignInDTO.builder()
                 .tokens(token)
                 .memberId(member.getId())
+                .loginType(member.getLoginType())
                 .email(member.getEmail())
                 .build();
 
@@ -241,6 +242,7 @@ public class AuthServiceImpl implements AuthService{
         return MemberResponseDTO.MemberSignInDTO.builder()
                 .tokens(tokenDTO)
                 .memberId(member.getId())
+                .loginType(member.getLoginType())
                 .email(member.getEmail())
                 .build();
     }
@@ -366,6 +368,7 @@ public class AuthServiceImpl implements AuthService{
         return MemberResponseDTO.MemberSignInDTO.builder()
                 .tokens(token)
                 .memberId(member.getId())
+                .loginType(member.getLoginType())
                 .email(member.getEmail())
                 .build();
     }

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -147,6 +147,9 @@ public class AuthServiceImpl implements AuthService{
         NaverMember.ResponseDTO responseDTO = naverOAuthService.getNaverMember(request, response, naverCallback);
         String email = responseDTO.getResponse().getEmail();
 
+        if (memberRepository.existsByEmailAndLoginTypeNot(email, LoginType.NAVER))
+            throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
+
         Boolean isSpotMember = Boolean.TRUE;
 
         // 가입되지 않은 회원이면 회원 정보 저장

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -20,6 +20,7 @@ import com.example.spot.web.dto.member.MemberRequestDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO;
 import com.example.spot.security.utils.SecurityUtils;
 import com.example.spot.service.message.MailService;
+import com.example.spot.web.dto.member.MemberResponseDTO.SocialLoginSignInDTO;
 import com.example.spot.web.dto.member.naver.NaverCallback;
 import com.example.spot.web.dto.member.naver.NaverMember;
 import com.example.spot.web.dto.token.TokenResponseDTO;
@@ -142,7 +143,7 @@ public class AuthServiceImpl implements AuthService{
     }
 
     @Override
-    public MemberResponseDTO.NaverSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException {
+    public SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException {
 
         NaverMember.ResponseDTO responseDTO = naverOAuthService.getNaverMember(request, response, naverCallback);
         String email = responseDTO.getResponse().getEmail();
@@ -171,7 +172,7 @@ public class AuthServiceImpl implements AuthService{
                 .email(member.getEmail())
                 .build();
 
-        return MemberResponseDTO.NaverSignInDTO.toDTO(isSpotMember, signInDTO);
+        return SocialLoginSignInDTO.toDTO(isSpotMember, signInDTO);
     }
 
     private void signUpWithNaver(NaverMember.ResponseDTO memberDTO) {

--- a/src/main/java/com/example/spot/service/member/MemberService.java
+++ b/src/main/java/com/example/spot/service/member/MemberService.java
@@ -17,9 +17,9 @@ public interface MemberService extends UserDetailsService {
     // 테스트 용 멤버 생성
     MemberResponseDTO.MemberTestDTO testMember(MemberInfoListDTO memberInfoListDTO);
 
-    MemberResponseDTO.MemberSignInDTO signUpByKAKAO(String code) throws JsonProcessingException;
+    MemberResponseDTO.SocialLoginSignInDTO signUpByKAKAO(String code) throws JsonProcessingException;
 
-    MemberResponseDTO.MemberSignInDTO signUpByKAKAOForTest(String code)
+    MemberResponseDTO.SocialLoginSignInDTO signUpByKAKAOForTest(String code)
         throws JsonProcessingException;
 
     void redirectURL() throws IOException;

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -93,6 +93,11 @@ public class MemberServiceImpl implements MemberService {
         // 응답에서 사용자 정보를 파싱
         KaKaoUser kaKaoUser = kaKaoOAuthService.getUserInfo(userInfoResponse);
 
+        if (memberRepository.existsByEmailAndLoginTypeNot(kaKaoUser.toMember().getEmail(), LoginType.KAKAO)){
+            log.info(kaKaoUser.toMember().getEmail());
+            throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
+        }
+
         // 사용자가 이미 존재하는지 확인
         if (memberRepository.existsByEmail(kaKaoUser.toMember().getEmail())) {
             // 존재하는 경우, 사용자 정보를 가져옴
@@ -260,6 +265,9 @@ public class MemberServiceImpl implements MemberService {
 
         // 응답에서 사용자 정보를 파싱
         KaKaoUser kaKaoUser = kaKaoOAuthService.getUserInfo(userInfoResponse);
+
+        if (memberRepository.existsByEmailAndLoginTypeNot(kaKaoUser.toMember().getEmail(), LoginType.KAKAO))
+            throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
 
         // 사용자가 이미 존재하는지 확인
         if (memberRepository.existsByEmail(kaKaoUser.toMember().getEmail())) {

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -116,6 +116,7 @@ public class MemberServiceImpl implements MemberService {
             MemberSignInDTO dto = MemberSignInDTO.builder()
                     .tokens(token)
                     .memberId(member.getId())
+                    .loginType(member.getLoginType())
                     .email(member.getEmail())
                     .build();
             return SocialLoginSignInDTO.toDTO(isSpotMember, dto);
@@ -134,6 +135,7 @@ public class MemberServiceImpl implements MemberService {
         MemberSignInDTO dto = MemberSignInDTO.builder()
                 .tokens(token)
                 .memberId(member.getId())
+                .loginType(member.getLoginType())
                 .email(member.getEmail())
                 .build();
         return SocialLoginSignInDTO.toDTO(isSpotMember, dto);
@@ -289,10 +291,11 @@ public class MemberServiceImpl implements MemberService {
 
             // 로그인 DTO 반환
             MemberSignInDTO memberSignInDto = MemberSignInDTO.builder()
-                .tokens(token)
-                .memberId(member.getId())
-                .email(member.getEmail())
-                .build();
+                    .tokens(token)
+                    .memberId(member.getId())
+                    .loginType(member.getLoginType())
+                    .email(member.getEmail())
+                    .build();
 
             return SocialLoginSignInDTO.toDTO(isSpotMember, memberSignInDto);
         }
@@ -309,6 +312,7 @@ public class MemberServiceImpl implements MemberService {
         MemberSignInDTO dto = MemberSignInDTO.builder()
                 .tokens(token)
                 .memberId(member.getId())
+                .loginType(member.getLoginType())
                 .email(member.getEmail())
                 .build();
         return SocialLoginSignInDTO.toDTO(isSpotMember, dto);

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -21,8 +21,10 @@ import com.example.spot.service.auth.KaKaoOAuthService;
 import com.example.spot.web.dto.member.MemberResponseDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberRegionDTO.RegionDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberSignInDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.MemberSignInDTO.MemberSignInDTOBuilder;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberStudyReasonDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberTestDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.SocialLoginSignInDTO;
 import com.example.spot.web.dto.member.kakao.KaKaoOAuthToken.KaKaoOAuthTokenDTO;
 import com.example.spot.web.dto.member.kakao.KaKaoUser;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
@@ -86,7 +88,7 @@ public class MemberServiceImpl implements MemberService {
      * @throws JsonProcessingException 카카오 사용자 정보 파싱 중 발생하는 예외
      */
     @Override
-    public MemberResponseDTO.MemberSignInDTO signUpByKAKAO(String accessToken) throws JsonProcessingException {
+    public MemberResponseDTO.SocialLoginSignInDTO signUpByKAKAO(String accessToken) throws JsonProcessingException {
         // 액세스 토큰을 사용하여 사용자 정보 요청
         ResponseEntity<String> userInfoResponse = kaKaoOAuthService.requestUserInfo(accessToken);
 
@@ -98,23 +100,25 @@ public class MemberServiceImpl implements MemberService {
             throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
         }
 
+        Boolean isSpotMember = false;
         // 사용자가 이미 존재하는지 확인
         if (memberRepository.existsByEmail(kaKaoUser.toMember().getEmail())) {
             // 존재하는 경우, 사용자 정보를 가져옴
             Member member = memberRepository.findByEmail(kaKaoUser.toMember().getEmail())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-
+            isSpotMember = true;
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
             saveRefreshToken(member, token);
 
             // 로그인 DTO 반환
-            return MemberResponseDTO.MemberSignInDTO.builder()
-                .tokens(token)
-                .memberId(member.getId())
-                .email(member.getEmail())
-                .build();
+            MemberSignInDTO dto = MemberSignInDTO.builder()
+                    .tokens(token)
+                    .memberId(member.getId())
+                    .email(member.getEmail())
+                    .build();
+            return SocialLoginSignInDTO.toDTO(isSpotMember, dto);
         }
 
 
@@ -127,11 +131,12 @@ public class MemberServiceImpl implements MemberService {
         saveRefreshToken(member, token);
 
         // 회원 가입 DTO 반환
-        return MemberResponseDTO.MemberSignInDTO.builder()
-            .tokens(token)
-            .memberId(member.getId())
-            .email(member.getEmail())
-            .build();
+        MemberSignInDTO dto = MemberSignInDTO.builder()
+                .tokens(token)
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .build();
+        return SocialLoginSignInDTO.toDTO(isSpotMember, dto);
     }
 
     /**
@@ -252,7 +257,7 @@ public class MemberServiceImpl implements MemberService {
      * @throws MemberHandler 이메일로 가입된 내역이 존재하지만, 실제로는 회원이 존재하지 않을 경우
      */
     @Override
-    public MemberSignInDTO signUpByKAKAOForTest(String code) throws JsonProcessingException {
+    public SocialLoginSignInDTO signUpByKAKAOForTest(String code) throws JsonProcessingException {
         // 카카오 OAuth 서비스에서 액세스 토큰 요청
         ResponseEntity<String> accessTokenResponse = kaKaoOAuthService.requestAccessToken(code);
 
@@ -269,11 +274,13 @@ public class MemberServiceImpl implements MemberService {
         if (memberRepository.existsByEmailAndLoginTypeNot(kaKaoUser.toMember().getEmail(), LoginType.KAKAO))
             throw new GeneralException(ErrorStatus._MEMBER_EMAIL_EXIST);
 
+        Boolean isSpotMember = false;
         // 사용자가 이미 존재하는지 확인
         if (memberRepository.existsByEmail(kaKaoUser.toMember().getEmail())) {
             // 존재하는 경우, 사용자 정보를 가져옴
             Member member = memberRepository.findByEmail(kaKaoUser.toMember().getEmail())
                 .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+            isSpotMember = true;
 
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
@@ -281,11 +288,13 @@ public class MemberServiceImpl implements MemberService {
             saveRefreshToken(member, token);
 
             // 로그인 DTO 반환
-            return MemberResponseDTO.MemberSignInDTO.builder()
+            MemberSignInDTO memberSignInDto = MemberSignInDTO.builder()
                 .tokens(token)
                 .memberId(member.getId())
                 .email(member.getEmail())
                 .build();
+
+            return SocialLoginSignInDTO.toDTO(isSpotMember, memberSignInDto);
         }
 
         // 존재하지 않는 경우, 새로운 회원 정보 저장
@@ -297,11 +306,12 @@ public class MemberServiceImpl implements MemberService {
         saveRefreshToken(member, token);
 
         // 회원 가입 DTO 반환
-        return MemberResponseDTO.MemberSignInDTO.builder()
-            .tokens(token)
-            .memberId(member.getId())
-            .email(member.getEmail())
-            .build();
+        MemberSignInDTO dto = MemberSignInDTO.builder()
+                .tokens(token)
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .build();
+        return SocialLoginSignInDTO.toDTO(isSpotMember, dto);
     }
 
     /**

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.example.spot.service.auth.AuthService;
 import com.example.spot.validation.annotation.TextLength;
 import com.example.spot.web.dto.member.MemberRequestDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.SocialLoginSignInDTO;
 import com.example.spot.web.dto.member.naver.NaverCallback;
 import com.example.spot.web.dto.token.TokenResponseDTO;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
@@ -88,10 +89,10 @@ public class AuthController {
             * 콜백 함수의 결과로 토큰 정보가 반환됩니다.
             """)
     @GetMapping("/members/sign-in/naver/redirect")
-    public ApiResponse<MemberResponseDTO.NaverSignInDTO> signInWithNaver(
+    public ApiResponse<SocialLoginSignInDTO> signInWithNaver(
             HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException {
-        MemberResponseDTO.NaverSignInDTO naverSignInDTO = authService.signInWithNaver(request, response, naverCallback);
-        return ApiResponse.onSuccess(SuccessStatus._MEMBER_SIGNED_IN, naverSignInDTO);
+        SocialLoginSignInDTO socialLoginSignInDTO = authService.signInWithNaver(request, response, naverCallback);
+        return ApiResponse.onSuccess(SuccessStatus._MEMBER_SIGNED_IN, socialLoginSignInDTO);
     }
 
 /* ----------------------------- 일반 로그인/회원가입 API ------------------------------------- */

--- a/src/main/java/com/example/spot/web/controller/MemberController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberController.java
@@ -10,6 +10,7 @@ import com.example.spot.web.dto.member.MemberResponseDTO.MemberRegionDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberSignInDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberStudyReasonDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.MemberTestDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.SocialLoginSignInDTO;
 import com.example.spot.web.dto.member.naver.NaverCallback;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.example.spot.validation.annotation.ExistMember;
@@ -110,8 +111,8 @@ public class MemberController {
             
            생성된 회원의 액세스 토큰과 Email이 반환 됩니다. """)
     @GetMapping("/members/sign-in/kakao/redirect")
-    public ApiResponse<MemberResponseDTO.MemberSignInDTO> redirectURL(@RequestParam String code) throws IOException {
-        MemberSignInDTO dto = memberService.signUpByKAKAOForTest(code);
+    public ApiResponse<MemberResponseDTO.SocialLoginSignInDTO> redirectURL(@RequestParam String code) throws IOException {
+        SocialLoginSignInDTO dto = memberService.signUpByKAKAOForTest(code);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_CREATED, dto);
     }
 
@@ -125,8 +126,8 @@ public class MemberController {
 
     @Parameter(name = "accessToken", description = "카카오 액세스 토큰을 입력 해 주세요. ", required = true)
     @GetMapping("/members/sign-in/kakao")
-    public ApiResponse<MemberResponseDTO.MemberSignInDTO> signInByKaKao(@RequestParam String accessToken) throws JsonProcessingException {
-        MemberSignInDTO dto = memberService.signUpByKAKAO(accessToken);
+    public ApiResponse<MemberResponseDTO.SocialLoginSignInDTO> signInByKaKao(@RequestParam String accessToken) throws JsonProcessingException {
+        SocialLoginSignInDTO dto = memberService.signUpByKAKAO(accessToken);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_CREATED, dto);
     }
 

--- a/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
@@ -85,6 +85,7 @@ public class MemberResponseDTO {
         private TokenDTO tokens;
         private String email;
         private Long memberId;
+        private LoginType loginType;
     }
 
     @Builder

--- a/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
@@ -16,13 +16,13 @@ public class MemberResponseDTO {
     @Getter
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     @Builder(access = AccessLevel.PRIVATE)
-    public static class NaverSignInDTO {
+    public static class SocialLoginSignInDTO {
 
         private final Boolean isSpotMember;
         private final MemberSignInDTO signInDTO;
 
-        public static NaverSignInDTO toDTO(Boolean isSpotMember, MemberSignInDTO signInDTO) {
-            return NaverSignInDTO.builder()
+        public static SocialLoginSignInDTO toDTO(Boolean isSpotMember, MemberSignInDTO signInDTO) {
+            return SocialLoginSignInDTO.builder()
                     .isSpotMember(isSpotMember)
                     .signInDTO(signInDTO)
                     .build();

--- a/src/main/java/com/example/spot/web/dto/member/google/CustomOAuth2User.java
+++ b/src/main/java/com/example/spot/web/dto/member/google/CustomOAuth2User.java
@@ -2,6 +2,7 @@ package com.example.spot.web.dto.member.google;
 
 import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.LoginType;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -16,6 +17,9 @@ public class CustomOAuth2User implements OAuth2User {
 
     private final Member member;
     private final Map<String, Object> attributes;
+
+    @Getter
+    private final Boolean isSpotMember;
 
     @Override
     public Map<String, Object> getAttributes() {
@@ -35,4 +39,5 @@ public class CustomOAuth2User implements OAuth2User {
 
         return null;
     }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#263 

<br/>

## 🔎 작업 내용
<img width="671" alt="스크린샷 2024-11-19 오후 3 00 03" src="https://github.com/user-attachments/assets/c605183d-66c0-4235-8d00-bcc0bc11b572">

- 동일한 이메일로 다른 종류의 소셜 로그인을 사용할 시, 이메일 중복으로 인한 데이터 무결성 에러가 발생
- 이를 해결하기 위해 소셜 로그인 시, 해당 이메일의 가입 유무를 확인하여 적절히 응답
- 또한, Naver 소셜 로그인과 다른 소셜 로그인의 응답을 통일 -> `isSpotMember` 추가 
- 로그인 및 회원 가입 시, `LoginType` 도 함께 응답 하도록 추가
<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<img width="556" alt="스크린샷 2024-11-19 오후 2 47 55" src="https://github.com/user-attachments/assets/3fba4caf-a77a-4057-8e05-0e6d1f8a9157">

1. 카카오로 가입된 이메일을 네이버로 로그인 하려고 시도 했을 때 응답한 메시지 -> 이메일 중복

<img width="1396" alt="스크린샷 2024-11-19 오후 2 48 13" src="https://github.com/user-attachments/assets/8c558962-6ceb-45c0-a92b-f4dac72bb87d">

2. 구글 -> 회원 가입 성공 예시 

<img width="1346" alt="스크린샷 2024-11-19 오후 2 48 29" src="https://github.com/user-attachments/assets/195712e1-51fb-4f81-a3ed-05c19760d72e">
3. 구글 -> 회원 가입 후 다시 로그인 한 경우 -> (2, 3번 `isSpotMember` 변경됨)

<img width="1217" alt="스크린샷 2024-11-19 오후 2 50 34" src="https://github.com/user-attachments/assets/e00ae998-a8ae-4670-bf55-a6f4803c668b">
<img width="1224" alt="스크린샷 2024-11-19 오후 2 50 28" src="https://github.com/user-attachments/assets/05c68301-0426-4917-b755-2a526ddeb49d">

4. 기본 로그인 예시

<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
