### PR TITLE
[FIX] 네이버 로그인에 대한 ExceptionAdvice 적용

### DIFF
--- a/src/main/java/com/example/spot/config/WebSecurity.java
+++ b/src/main/java/com/example/spot/config/WebSecurity.java
@@ -2,11 +2,11 @@ package com.example.spot.config;
 
 
 import com.example.spot.security.filters.JwtAuthenticationFilter;
+import com.example.spot.security.oauth.CustomOAuth2UserService;
+import com.example.spot.security.oauth.CustomOAuthSuccessHandler;
 import com.example.spot.security.utils.JwtTokenProvider;
 import com.example.spot.service.member.MemberService;
 import com.example.spot.service.member.UserDetailsServiceCustom;
-import com.example.spot.security.oauth.CustomOAuth2UserService;
-import com.example.spot.security.oauth.CustomOAuthSuccessHandler;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.annotation.Bean;
@@ -57,7 +57,7 @@ public class WebSecurity {
                         .requestMatchers(new AntPathRequestMatcher("/spot/login", "POST")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/naver", "POST")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/naver/redirect", "GET")).permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/naver/authorize", "GET")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/naver/authorize/test", "GET")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/spot/login/kakao", "GET")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/kakao", "GET")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/spot/members/sign-in/kakao/redirect", "GET")).permitAll()

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -7,7 +7,6 @@ import com.example.spot.web.dto.member.naver.NaverCallback;
 import com.example.spot.web.dto.member.naver.NaverOAuthToken;
 import com.example.spot.web.dto.token.TokenResponseDTO;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -20,9 +19,9 @@ public interface AuthService {
 
     void authorizeWithNaver(HttpServletRequest request, HttpServletResponse response);
 
-    SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException;
+    SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws Exception;
 
-    SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverOAuthToken.NaverTokenIssuanceDTO naverTokenDTO) throws JsonProcessingException;
+    SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverOAuthToken.NaverTokenIssuanceDTO naverTokenDTO) throws Exception;
 
     MemberResponseDTO.MemberSignInDTO signIn(MemberRequestDTO.SignInDTO signInDTO);
 

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -159,7 +159,7 @@ public class AuthServiceImpl implements AuthService{
      * @return SocialLoginSignInDTO(isSpotMember, signInDTO-토큰정보)
      */
     @Override
-    public SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException {
+    public SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws Exception {
         NaverMember.ResponseDTO responseDTO = naverOAuthService.getNaverMember(request, response, naverCallback);
         return getSocialLoginSignInDTO(responseDTO);
     }
@@ -174,7 +174,7 @@ public class AuthServiceImpl implements AuthService{
      * @return SocialLoginSignInDTO(isSpotMember, signInDTO-토큰정보)
      */
     @Override
-    public SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverOAuthToken.NaverTokenIssuanceDTO naverTokenDTO) throws JsonProcessingException {
+    public SocialLoginSignInDTO signInWithNaver(HttpServletRequest request, HttpServletResponse response, NaverOAuthToken.NaverTokenIssuanceDTO naverTokenDTO) throws Exception {
         NaverMember.ResponseDTO responseDTO = naverOAuthService.getNaverMember(request, response, naverTokenDTO);
         return getSocialLoginSignInDTO(responseDTO);
     }

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -140,7 +140,6 @@ public class AuthServiceImpl implements AuthService{
     @Override
     public void authorizeWithNaver(HttpServletRequest request, HttpServletResponse response) {
         String url = naverOAuthService.getNaverAuthorizeUrl();
-        System.out.println(url);
         try {
             response.sendRedirect(url);
         } catch (Exception e) {

--- a/src/main/java/com/example/spot/service/auth/NaverOAuthService.java
+++ b/src/main/java/com/example/spot/service/auth/NaverOAuthService.java
@@ -47,8 +47,8 @@ public class NaverOAuthService {
         return UriComponentsBuilder.fromHttpUrl(NAVER_OAUTH_URL)
                 .queryParam("response_type", "code")
                 .queryParam("client_id", NAVER_CLIENT_ID)
-                .queryParam("redirect_uri", URLEncoder.encode(NAVER_CALL_BACK_URL, StandardCharsets.UTF_8))
-                .queryParam("state", URLEncoder.encode(CSRF_TOKEN, StandardCharsets.UTF_8))
+                .queryParam("redirect_uri", NAVER_CALL_BACK_URL)
+                .queryParam("state",CSRF_TOKEN)
                 .build()
                 .toUriString();
     }
@@ -68,7 +68,7 @@ public class NaverOAuthService {
         ObjectMapper mapper = new ObjectMapper();
         NaverOAuthToken.NaverTokenIssuanceDTO naverTokenIssuanceDTO
                 = mapper.readValue(accessToken, NaverOAuthToken.NaverTokenIssuanceDTO.class);
-
+        
         // 네이버 프로필 반환
         String naverMember = getNaverProfile(naverTokenIssuanceDTO);
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/example/spot/service/auth/NaverOAuthService.java
+++ b/src/main/java/com/example/spot/service/auth/NaverOAuthService.java
@@ -5,7 +5,6 @@ import com.example.spot.api.exception.handler.MemberHandler;
 import com.example.spot.web.dto.member.naver.NaverCallback;
 import com.example.spot.web.dto.member.naver.NaverMember;
 import com.example.spot.web.dto.member.naver.NaverOAuthToken;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -62,7 +61,7 @@ public class NaverOAuthService {
      * @param naverCallback : Callback 함수 성공시 반환되는 요소(code, state, error, error_description)
      * @return 네이버 프로필 정보
      */
-    public NaverMember.ResponseDTO getNaverMember(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException {
+    public NaverMember.ResponseDTO getNaverMember(HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws Exception {
 
         // 네이버 액세스 토큰 발급
         String accessToken = issueNaverAccessToken(naverCallback.getCode());
@@ -83,7 +82,7 @@ public class NaverOAuthService {
      * @param response : HttpServletResponse
      * @return 네이버 프로필 정보
      */
-    public NaverMember.ResponseDTO getNaverMember(HttpServletRequest request, HttpServletResponse response, NaverOAuthToken.NaverTokenIssuanceDTO naverTokenDTO) throws JsonProcessingException {
+    public NaverMember.ResponseDTO getNaverMember(HttpServletRequest request, HttpServletResponse response, NaverOAuthToken.NaverTokenIssuanceDTO naverTokenDTO) throws Exception {
         // 네이버 프로필 반환
         String naverMember = getNaverProfile(naverTokenDTO);
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -19,6 +19,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -103,7 +104,7 @@ public class AuthController {
             * 회원가입이 되어있는 경우 -> 로그인 & 토큰 정보 반환
             * 회원가입이 되어있지 않은 경우 -> 회원가입 & 로그인 & 토큰 정보 반환
             """)
-    @PostMapping("/members/sign-in/naver")
+    @PostMapping(value = "/members/sign-in/naver", produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<SocialLoginSignInDTO> signInWithNaver(
             HttpServletRequest request,
             HttpServletResponse response,

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -11,7 +11,6 @@ import com.example.spot.web.dto.member.naver.NaverCallback;
 import com.example.spot.web.dto.member.naver.NaverOAuthToken;
 import com.example.spot.web.dto.token.TokenResponseDTO;
 import com.example.spot.web.dto.token.TokenResponseDTO.TokenDTO;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -92,7 +91,7 @@ public class AuthController {
             """)
     @GetMapping("/members/sign-in/naver/redirect/test")
     public ApiResponse<SocialLoginSignInDTO> signInWithNaver(
-            HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws JsonProcessingException {
+            HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws Exception {
         SocialLoginSignInDTO socialLoginSignInDTO = authService.signInWithNaver(request, response, naverCallback);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_SIGNED_IN, socialLoginSignInDTO);
     }
@@ -109,7 +108,7 @@ public class AuthController {
             HttpServletRequest request,
             HttpServletResponse response,
             @RequestBody NaverOAuthToken.NaverTokenIssuanceDTO naverTokenDTO
-    ) throws JsonProcessingException {
+    ) throws Exception {
         SocialLoginSignInDTO socialLoginSignInDTO = authService.signInWithNaver(request, response, naverTokenDTO);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_SIGNED_IN, socialLoginSignInDTO);
     }

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -89,7 +89,7 @@ public class AuthController {
             * 회원가입이 되어있지 않은 경우 -> 회원가입 & 로그인 & 토큰 정보 반환
             * 콜백 함수의 결과로 토큰 정보가 반환됩니다.
             """)
-    @GetMapping("/members/sign-in/naver/redirect/test")
+    @GetMapping("/members/sign-in/naver/redirect")
     public ApiResponse<SocialLoginSignInDTO> signInWithNaver(
             HttpServletRequest request, HttpServletResponse response, NaverCallback naverCallback) throws Exception {
         SocialLoginSignInDTO socialLoginSignInDTO = authService.signInWithNaver(request, response, naverCallback);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.

네이버 로그인 시 내부적으로 네이버 API를 호출하고 JsonProcessingException으로 throw하는 로직이 있었는데, ExceptionAdvice에 JsonProcessingException에 대한 예외 처리를 별도로 구현하지 않아서 Exception으로 throw 하도록 수정했습니다. 

JsonProcessingException이 발생하더라도 저희가 지정한 Json 포맷으로 응답을 전송할 수 있도록 만든 것입니당 😆



<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
