### PR TITLE
[MODIFY] 게시글 단건 조회 시 작성자 확인 필드 추가

### DIFF
--- a/src/main/java/com/example/spot/service/post/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/post/PostQueryServiceImpl.java
@@ -73,11 +73,14 @@ public class PostQueryServiceImpl implements PostQueryService {
         Long currentUserId = getCurrentUserId();
         boolean scrapedByCurrentUser = memberScrapRepository.existsByMemberIdAndPostId(currentUserId, postId);
 
+        // 현재 사용자가 게시글 작성자인지 여부
+        boolean createdByCurrentUser = currentUserId.equals(post.getMember().getId());
+
         // 해당 게시글의 댓글 조회
         CommentResponse commentResponse = getCommentsByPostId(post.getId());
 
         // 조회된 게시글을 PostSingleResponse로 변환하여 반환 (익명처리일 경우 프로필 이미지를 DEFAULT_PROFILE_IMAGE_URL로 반환)
-        return PostSingleResponse.toDTO(post, likeCount, scrapCount, commentResponse, likedByCurrentUser, scrapedByCurrentUser, DEFAULT_PROFILE_IMAGE_URL);
+        return PostSingleResponse.toDTO(post, likeCount, scrapCount, commentResponse, likedByCurrentUser, scrapedByCurrentUser, createdByCurrentUser, DEFAULT_PROFILE_IMAGE_URL);
     }
 
     /**

--- a/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostSingleResponse.java
@@ -86,6 +86,11 @@ public class PostSingleResponse {
     private boolean scrapedByCurrentUser;
 
     @Schema(
+            description = "현재 사용자의 해당 게시글 작성 여부입니다."
+    )
+    private boolean createdByCurrentUser;
+
+    @Schema(
             description = "댓글 리스트입니다.",
             format = "array"
     )
@@ -118,12 +123,11 @@ public class PostSingleResponse {
         return profileImage;
     }
 
-    public static PostSingleResponse toDTO(Post post, long likeCount, long scrapCount, CommentResponse commentResponse, boolean likedByCurrentUser, boolean scrapedByCurrentUser, String defaultProfileImageUrl) {
+    public static PostSingleResponse toDTO(Post post, long likeCount, long scrapCount, CommentResponse commentResponse, boolean likedByCurrentUser, boolean scrapedByCurrentUser, boolean createdByCurrentUser, String defaultProfileImageUrl) {
         // 작성자가 익명인지 확인하여 작성자 이름 설정
         String writerName = judgeAnonymous(post.isAnonymous(), post.getMember().getName());
         // 작성자가 익명인지 확인하여 프로필 반환
         String writerImage = anonymousProfileImage(post.isAnonymous(), post.getMember().getProfileImage(), defaultProfileImageUrl);
-
 
         return PostSingleResponse.builder()
                 .type(post.getBoard().name())
@@ -137,6 +141,7 @@ public class PostSingleResponse {
                 .content(post.getContent())
                 .likeCount(likeCount)
                 .likedByCurrentUser(likedByCurrentUser)
+                .createdByCurrentUser(createdByCurrentUser)
                 .commentCount(commentResponse.getComments().size())
                 .viewCount(post.getHitNum())
                 .commentResponses(commentResponse)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #331

<br/>

## 🔎 작업 내용

> 게시글 단건 조회 시 응답에 현재 사용자가 작성자인지 확인하는 필드 추가

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
