### PR TITLE
[FEAT] 스터디 게시글 편집 API 구현

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -97,6 +97,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _STUDY_POST_COMMENT_NULL(HttpStatus.BAD_REQUEST, "POST4016", "댓글 아이디가 입력되지 않았습니다."),
     _STUDY_POST_COMMENT_REACTIOM_ID_NULL(HttpStatus.BAD_REQUEST, "POST4017", "댓글 반응 아이디가 입력되지 않았습니다."),
     _STUDY_POST_COMMENT_REACTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST4018", "댓글 반응이 존재하지 않습니다."),
+    _STUDY_POST_UPDATE_INVALID(HttpStatus.FORBIDDEN, "POST4019", "게시글 작성자만 변경 가능합니다."),
 
     //스터디 일정 관련 에러
     _STUDY_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE4001", "스터디 일정을 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/domain/study/StudyPost.java
+++ b/src/main/java/com/example/spot/domain/study/StudyPost.java
@@ -5,6 +5,7 @@ import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.enums.Theme;
 import com.example.spot.domain.mapping.StudyLikedPost;
 import com.example.spot.domain.mapping.StudyPostImage;
+import com.example.spot.web.dto.memberstudy.request.StudyPostRequestDTO;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
@@ -134,5 +135,21 @@ public class StudyPost extends BaseEntity {
 
     public void addStudyPostReport(StudyPostReport studyPostReport) {
         studyPostReports.add(studyPostReport);
+    }
+
+    public void updatePost(StudyPostRequestDTO.PostDTO requestDTO) {
+        isAnnouncement = requestDTO.getIsAnnouncement();
+        theme = requestDTO.getTheme();
+        title = requestDTO.getTitle();
+        content = requestDTO.getContent();
+
+        if (isAnnouncement) {
+            announcedAt = LocalDateTime.now();
+        } else {
+            announcedAt = null;
+        }
+
+        member.updateStudyPost(this);
+        study.updateStudyPost(this);
     }
 }

--- a/src/main/java/com/example/spot/repository/StudyPostImageRepository.java
+++ b/src/main/java/com/example/spot/repository/StudyPostImageRepository.java
@@ -2,9 +2,17 @@ package com.example.spot.repository;
 
 import com.example.spot.domain.mapping.StudyPostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface StudyPostImageRepository extends JpaRepository<StudyPostImage, Long> {
-    void deleteAllByStudyPostId(Long studyPostId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM StudyPostImage spi WHERE spi.studyPost.id = :studyPostId")
+    void deleteAllByStudyPostId(@Param("studyPostId") Long studyPostId);
 }

--- a/src/main/java/com/example/spot/service/studypost/StudyPostCommandService.java
+++ b/src/main/java/com/example/spot/service/studypost/StudyPostCommandService.java
@@ -10,6 +10,9 @@ public interface StudyPostCommandService {
     // 스터디 게시글 생성
     StudyPostResDTO.PostPreviewDTO createPost(Long studyId, StudyPostRequestDTO.PostDTO postRequestDTO);
 
+    // 스터디 게시글 편집
+    StudyPostResDTO.PostPreviewDTO updatePost(Long studyId, Long postId, StudyPostRequestDTO.PostDTO postDTO);
+
     // 스터디 게시글 삭제
     StudyPostResDTO.PostPreviewDTO deletePost(Long studyId, Long postId);
 

--- a/src/main/java/com/example/spot/web/controller/StudyPostController.java
+++ b/src/main/java/com/example/spot/web/controller/StudyPostController.java
@@ -61,6 +61,26 @@ public class StudyPostController {
         return ApiResponse.onSuccess(SuccessStatus._STUDY_POST_CREATED, postPreviewDTO);
     }
 
+    @Tag(name= "스터디 게시글")
+    @Operation(summary = "[스터디 게시글] 게시글 편집하기", description = """
+            로그인한 회원이 참여하는 특정 스터디에서 작성한 게시글을 편집합니다.
+            수정사항은 study_post db에 반영됩니다.
+            """)
+    @Parameter(name = "studyId", description = "스터디의 id를 입력합니다.", required = true)
+    @Parameter(name = "postId", description = "편집할 스터디 게시글의 id를 입력합니다.", required = true)
+    @PatchMapping(value = "/studies/{studyId}/posts/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<StudyPostResDTO.PostPreviewDTO> updatePost(
+            @PathVariable @ExistStudy Long studyId,
+            @PathVariable @ExistStudyPost Long postId,
+            @ModelAttribute(name= "post") @Valid StudyPostRequestDTO.PostDTO postDTO
+    ) {
+        if (postDTO.getImages() == null) {
+            postDTO.initImages();
+        }
+        StudyPostResDTO.PostPreviewDTO postPreviewDTO = studyPostCommandService.updatePost(studyId, postId, postDTO);
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_POST_UPDATED, postPreviewDTO);
+    }
+
     @Tag(name = "스터디 게시글")
     @Operation(summary = "[스터디 게시글] 게시글 삭제하기", description = """ 
         ## [스터디 게시글] 로그인한 회원이 참여하는 특정 스터디에서 작성한 게시글을 삭제합니다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 
- #348 
- SPOT-215

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.
- 스터디 게시글 편집 API 구현 (게시글 생성 API와 RequestDTO 통일)

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
