### PR TITLE
[FEAT] 스터디 정보 수정 및 관련 API 구현 

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -81,6 +81,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _STUDY_OWNER_ONLY_CAN_TERMINATE(HttpStatus.BAD_REQUEST, "STUDY4018", "스터디장만 스터디를 종료할 수 있습니다."),
     _STUDY_ALREADY_TERMINATED(HttpStatus.BAD_REQUEST, "STUDY4019", "이미 종료된 스터디입니다."),
     _OWNED_STUDY_EXISTS(HttpStatus.BAD_REQUEST, "STUDY4020", "운영중인 스터디가 존재합니다."),
+    _STUDY_NOT_OWNER(HttpStatus.FORBIDDEN, "STUDY4021", "스터디장이 아닙니다."),
 
     //스터디 게시글 관련 에러
     _STUDY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4001", "스터디 게시글을 찾을 수 없습니다."),

--- a/src/main/java/com/example/spot/domain/Region.java
+++ b/src/main/java/com/example/spot/domain/Region.java
@@ -51,4 +51,8 @@ public class Region extends BaseEntity {
         prefferedRegionList.add(preferredRegion);
         preferredRegion.setRegion(this);
     }
+
+    public String toRegionString() {
+        return province + " " + district + " " + neighborhood;
+    }
 }

--- a/src/main/java/com/example/spot/domain/study/Study.java
+++ b/src/main/java/com/example/spot/domain/study/Study.java
@@ -6,6 +6,7 @@ import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.enums.Gender;
 import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.enums.StudyState;
+import com.example.spot.domain.enums.ThemeType;
 import com.example.spot.domain.mapping.MemberStudy;
 import com.example.spot.domain.mapping.PreferredStudy;
 import com.example.spot.domain.mapping.RegionStudy;
@@ -206,5 +207,21 @@ public class Study extends BaseEntity {
         this.studyState = StudyState.COMPLETED;
         this.status = Status.OFF;
         this.performance = performance;
+    }
+
+    public void updateStudyInfo(
+            String title, String introduction, String goal, Boolean isOnline, Boolean hasFee, Integer fee, Integer minAge, Integer maxAge,
+            Gender gender, Long maxPeople, String profileImage) {
+        this.title = title;
+        this.introduction = introduction;
+        this.goal = goal;
+        this.isOnline = isOnline;
+        this.hasFee = hasFee;
+        this.fee = fee;
+        this.minAge = minAge;
+        this.maxAge = maxAge;
+        this.gender = gender;
+        this.maxPeople = maxPeople;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -25,6 +25,8 @@ public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> 
 
     Optional<MemberStudy> findByMemberIdAndStudyIdAndIsOwned(Long memberId, Long studyId, Boolean isOwned);
 
+    Optional<MemberStudy> findByMemberIdAndStudyId(Long memberId, Long studyId);
+
     long countByStatusAndStudyId(ApplicationStatus status, Long studyId);
     long countByMemberIdAndStatus(Long memberId, ApplicationStatus status);
     long countByMemberIdAndIsOwned(Long memberId, Boolean isOwned);

--- a/src/main/java/com/example/spot/repository/RegionStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/RegionStudyRepository.java
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface RegionStudyRepository extends JpaRepository<RegionStudy, Long> {
     List<RegionStudy> findAllByRegion(Region region);
 
+    void deleteByStudyId(Long studyId);
 }

--- a/src/main/java/com/example/spot/repository/StudyThemeRepository.java
+++ b/src/main/java/com/example/spot/repository/StudyThemeRepository.java
@@ -13,4 +13,6 @@ public interface StudyThemeRepository extends JpaRepository<StudyTheme, Long> {
     List<StudyTheme> findAllByTheme(Theme theme);
     StudyTheme findByTheme(Theme theme);
 
+    void deleteByStudyId(Long studyId);
+
 }

--- a/src/main/java/com/example/spot/service/study/StudyCommandService.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandService.java
@@ -2,6 +2,7 @@ package com.example.spot.service.study;
 
 import com.example.spot.web.dto.study.request.StudyJoinRequestDTO;
 import com.example.spot.web.dto.study.request.StudyRegisterRequestDTO;
+import com.example.spot.web.dto.study.response.StudyInfoResponseDTO;
 import com.example.spot.web.dto.study.response.StudyJoinResponseDTO;
 import com.example.spot.web.dto.study.response.StudyLikeResponseDTO;
 import com.example.spot.web.dto.study.response.StudyRegisterResponseDTO;
@@ -15,4 +16,7 @@ public interface StudyCommandService {
     StudyLikeResponseDTO likeStudy(Long memberId, Long studyId);
 
     void addHotKeyword(String keyword);
+
+    // 스터디 정보 수정
+    StudyRegisterResponseDTO.RegisterDTO updateStudyInfo(Long studyId, StudyRegisterRequestDTO.RegisterDTO studyInfoDTO);
 }

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.spot.domain.Member;
 import com.example.spot.domain.Region;
 import com.example.spot.domain.Theme;
 import com.example.spot.domain.enums.ApplicationStatus;
+import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.enums.StudyLikeStatus;
 import com.example.spot.domain.enums.StudySortBy;
 import com.example.spot.domain.enums.ThemeType;
@@ -756,9 +757,15 @@ public class StudyQueryServiceImpl implements StudyQueryService {
         // 회원이 참가하고 있는 스터디 조회
         List<Study> studies = studyRepository.findByMemberStudy(memberStudies, pageable);
 
+        // 스터디가 끝났으면 제외
+        studies = studies.stream()
+                .filter(study -> study.getStatus().equals(Status.ON))
+                .toList();
+
         // 조회된 스터디가 없을 경우
         if (studies.isEmpty())
             throw new StudyHandler(ErrorStatus._STUDY_IS_NOT_MATCH);
+
         // 전체 스터디 수
         long totalElements = memberStudyRepository.countByMemberIdAndStatus(memberId, ApplicationStatus.APPROVED);
         return getDTOs(studies, pageable, totalElements, memberId);
@@ -822,6 +829,10 @@ public class StudyQueryServiceImpl implements StudyQueryService {
         // 회원이 모집중인 스터디 조회
         List<Study> studies = studyRepository.findRecruitingStudiesByMemberStudy(memberStudies, pageable);
 
+        studies = studies.stream()
+                .filter(study -> study.getStatus().equals(Status.ON))
+                .toList();
+
         // 조회된 스터디가 없을 경우
         if (studies.isEmpty())
             throw new StudyHandler(ErrorStatus._STUDY_IS_NOT_MATCH);
@@ -852,6 +863,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
 
         return memberStudies.stream()
             .filter(memberStudy -> memberStudy.getStatus().equals(ApplicationStatus.APPROVED))
+                .filter(memberStudy -> memberStudy.getStudy().getStatus().equals(Status.ON))
             .map(memberStudy -> memberStudy.getStudy().getId())
             .toList();
     }

--- a/src/main/java/com/example/spot/web/controller/MemberStudyController.java
+++ b/src/main/java/com/example/spot/web/controller/MemberStudyController.java
@@ -15,6 +15,7 @@ import com.example.spot.web.dto.memberstudy.request.toDo.ToDoListResponseDTO.ToD
 import com.example.spot.web.dto.memberstudy.request.toDo.ToDoListResponseDTO.ToDoListSearchResponseDTO;
 import com.example.spot.web.dto.memberstudy.request.toDo.ToDoListResponseDTO.ToDoListUpdateResponseDTO;
 import com.example.spot.web.dto.memberstudy.response.*;
+import com.example.spot.web.dto.study.request.StudyRegisterRequestDTO;
 import com.example.spot.web.dto.study.response.*;
 import com.example.spot.web.dto.study.response.StudyMemberResponseDTO;
 import com.example.spot.web.dto.study.response.StudyMemberResponseDTO.StudyApplicantDTO;
@@ -87,13 +88,6 @@ public class MemberStudyController {
         return ApiResponse.onSuccess(SuccessStatus._STUDY_TERMINATED, terminationDTO);
     }
 
-//    @Operation(summary = "[데모 데이 이후 개발 -> 진행중인 스터디] 스터디 정보 수정하기", description = """
-//        ## [진행중인 스터디] 마이페이지 > 진행중 > 진행중인 스터디의 메뉴 클릭, 로그인한 회원이 운영중인 스터디의 정보를 수정합니다.
-//        로그인한 회원이 운영하는 특정 스터디에 대해 study 정보를 수정합니다.
-//        """)
-//    @PatchMapping("/studies/{studyId}")
-//    public void updateStudy(@PathVariable @ExistStudy Long studyId) {
-//    }
 
 /* ----------------------------- 모집중인 스터디 관련 API ------------------------------------- */
 

--- a/src/main/java/com/example/spot/web/controller/StudyController.java
+++ b/src/main/java/com/example/spot/web/controller/StudyController.java
@@ -73,6 +73,17 @@ public class StudyController {
         return ApiResponse.onSuccess(SuccessStatus._STUDY_CREATED, studyRegisterResponseDTO);
     }
 
+    @Operation(summary = "[스터디 정보 수정] 스터디 정보 수정하기", description = """
+        ## [스터디 정보 수정] 로그인한 회원이 운영중인 스터디의 정보를 수정합니다.
+        로그인한 회원이 운영하는 특정 스터디에 대해 study 정보를 수정합니다.
+        """)
+    @PatchMapping("/studies/{studyId}")
+    public ApiResponse<StudyRegisterResponseDTO.RegisterDTO>  updateStudy(@PathVariable @ExistStudy Long studyId,
+                            @RequestBody @Valid StudyRegisterRequestDTO.RegisterDTO studyRegisterRequestDTO)  {
+        return ApiResponse.onSuccess(SuccessStatus._OK, studyCommandService.updateStudyInfo(studyId, studyRegisterRequestDTO));
+
+    }
+
 /* ----------------------------- 스터디 찜하기 관련 API ------------------------------------- */
 
     @PostMapping("/studies/{studyId}/like")

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
@@ -81,7 +81,7 @@ public class StudyInfoResponseDTO {
                             .map(memberStudy -> { return memberStudy.getTheme().getStudyTheme();})
                             .toList())
                     .regions(study.getRegionStudies().stream()
-                            .map(memberStudy -> { return memberStudy.getRegion().toRegionString();})
+                            .map(memberStudy -> { return memberStudy.getRegion().getCode();})
                             .toList())
                     .goal(study.getGoal())
                     .introduction(study.getIntroduction())

--- a/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/study/response/StudyInfoResponseDTO.java
@@ -32,6 +32,7 @@ public class StudyInfoResponseDTO {
         private final Integer fee;
         private final Boolean isOnline;
         private final List<ThemeType> themes;
+        private final List<String> regions;
         private final String goal;
         private final String introduction;
 
@@ -39,7 +40,7 @@ public class StudyInfoResponseDTO {
         private StudyInfoDTO(Long studyId, String studyName, StudyOwnerDTO studyOwner,
                              Long hitNum, Integer heartCount, Integer memberCount, Boolean isLiked, Long maxPeople, Gender gender,
                              Integer minAge, Integer maxAge, Integer fee, Boolean isOnline,
-                             List<ThemeType> themes, String goal, String introduction) {
+                             List<ThemeType> themes, List<String> regions,String goal, String introduction) {
             this.studyId = studyId;
             this.studyName = studyName;
             this.studyOwner = studyOwner;
@@ -53,6 +54,7 @@ public class StudyInfoResponseDTO {
             this.fee = fee;
             this.isOnline = isOnline;
             this.themes = themes;
+            this.regions = regions;
             this.goal = goal;
             this.introduction = introduction;
         }
@@ -77,6 +79,9 @@ public class StudyInfoResponseDTO {
                     .isOnline(study.getIsOnline())
                     .themes(study.getStudyThemes().stream()
                             .map(memberStudy -> { return memberStudy.getTheme().getStudyTheme();})
+                            .toList())
+                    .regions(study.getRegionStudies().stream()
+                            .map(memberStudy -> { return memberStudy.getRegion().toRegionString();})
                             .toList())
                     .goal(study.getGoal())
                     .introduction(study.getIntroduction())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#371 

<br/>

## 🔎 작업 내용

1. 스터디 정보 수정 API 구현 
2. 참여 및 모집 중인 스터디 조회 시, 종료 상태 스터디는 조회 하지 않도록 필터링 조건 추가
3. 스터디 세부 정보 조회 시, 지역 정보도 응답. 

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<img width="801" alt="스크린샷 2025-03-21 오후 1 50 47" src="https://github.com/user-attachments/assets/0c5bccf1-c200-42e3-8c1c-5a6183bb0eca" />

<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
