### PR TITLE
[FEAT] 카카오 소셜 로그인 시, 프로필 이미지 업데이트 하도록 설정

### DIFF
--- a/src/main/java/com/example/spot/domain/Member.java
+++ b/src/main/java/com/example/spot/domain/Member.java
@@ -282,6 +282,10 @@ public class Member extends BaseEntity {
         this.profileImage = req.getProfileImage();
     }
 
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
     public void addStudyPost(StudyPost studyPost) {
         if (this.studyPostList == null) {
             this.studyPostList = new ArrayList<>();

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -108,6 +108,9 @@ public class MemberServiceImpl implements MemberService {
             // 존재하는 경우, 사용자 정보를 가져옴
             Member member = memberRepository.findByEmail(kaKaoUser.toMember().getEmail())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
+
+            updateMemberProfileImage(member, kaKaoUser);
+
             isSpotMember = true;
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
@@ -141,6 +144,12 @@ public class MemberServiceImpl implements MemberService {
                 .email(member.getEmail())
                 .build();
         return SocialLoginSignInDTO.toDTO(isSpotMember, dto);
+    }
+
+    private void updateMemberProfileImage(Member member, KaKaoUser kaKaoUser) {
+        if (!member.getProfileImage().equals(kaKaoUser.getProperties().getProfile_image())) {
+           member.updateProfileImage(kaKaoUser.getProperties().getProfile_image());
+        }
     }
 
     /**
@@ -298,6 +307,8 @@ public class MemberServiceImpl implements MemberService {
             // 존재하는 경우, 사용자 정보를 가져옴
             Member member = memberRepository.findByEmail(kaKaoUser.toMember().getEmail())
                 .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+
+            updateMemberProfileImage(member, kaKaoUser);
 
             // 탈퇴한(inactive) 회원이면 기존 정보 삭제
             if (member.getInactive() != null) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#377

<br/>

## 🔎 작업 내용

1. 카카오 소셜 로그인 시, 카카오톡 프로필 사진과 동기화(업데이트) 하도록 설정

<br/>

