### PR TITLE
[FEATURE] 게시글 수정 시, 이미지도 수정할 수 있도록 로직 구현

### DIFF
--- a/src/main/java/com/example/spot/domain/Post.java
+++ b/src/main/java/com/example/spot/domain/Post.java
@@ -67,23 +67,26 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public void edit(PostUpdateRequest postUpdateRequest) {
-        String title = postUpdateRequest.getTitle();
-        if (StringUtils.hasText(title)) {
-            this.title = postUpdateRequest.getTitle();
-        }
-        String content = postUpdateRequest.getContent();
-        if (StringUtils.hasText(content)) {
-            this.content = content;
+    public void edit(PostUpdateRequest request, List<String> images) {
+        if (StringUtils.hasText(request.getTitle())) {
+            this.title = request.getTitle();
         }
 
-        this.isAnonymous = postUpdateRequest.isAnonymous();
+        if (StringUtils.hasText(request.getContent())) {
+            this.content = request.getContent();
+        }
 
-        Board type = postUpdateRequest.getType();
-        if (type != null) {
-            this.board = type;
+        this.isAnonymous = request.isAnonymous();
+
+        this.image = (images != null && !images.isEmpty() && StringUtils.hasText(images.get(0)))
+                ? images.get(0)
+                : null;
+
+        if (request.getType() != null) {
+            this.board = request.getType();
         }
     }
+
 
     public void viewHit() {
         this.hitNum++;

--- a/src/main/java/com/example/spot/service/post/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/post/PostCommandServiceImpl.java
@@ -70,9 +70,9 @@ public class PostCommandServiceImpl implements PostCommandService {
         return PostCreateResponse.toDTO(post);
     }
 
-    private List<String> getImageUrls(PostCreateRequest postCreateRequest) {
-        if (postCreateRequest.getImage() != null) {
-            ImageUploadResponse imageUploadResponse = s3ImageService.uploadImages(List.of(postCreateRequest.getImage()));
+    private List<String> getImageUrls(MultipartFile imageFile) {
+        if (imageFile != null) {
+            ImageUploadResponse imageUploadResponse = s3ImageService.uploadImages(List.of(imageFile));
 
             return imageUploadResponse.getImageUrls().stream()
                     .map(Images::getImageUrl)

--- a/src/main/java/com/example/spot/service/post/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/post/PostCommandServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.web.multipart.MultipartFile;
 
 import static com.example.spot.security.utils.SecurityUtils.getCurrentUserId;
 
@@ -58,7 +59,7 @@ public class PostCommandServiceImpl implements PostCommandService {
             throw new PostHandler(ErrorStatus._FORBIDDEN); // 관리자만 접근 가능
         }
 
-        List<String> imageUrls = getImageUrls(postCreateRequest);
+        List<String> imageUrls = getImageUrls(postCreateRequest.getImage());
 
         // Post 객체 생성 및 연관 관계 설정
         Post post = createPostEntity(postCreateRequest, member, imageUrls);
@@ -139,7 +140,7 @@ public class PostCommandServiceImpl implements PostCommandService {
         }
 
         // 게시글 수정
-        post.edit(postUpdateRequest);
+        post.edit(postUpdateRequest, getImageUrls(postUpdateRequest.getImage()));
 
         // 수정된 게시글 정보 반환
         return PostCreateResponse.toDTO(post);

--- a/src/main/java/com/example/spot/web/controller/PostController.java
+++ b/src/main/java/com/example/spot/web/controller/PostController.java
@@ -141,7 +141,7 @@ public class PostController {
             description = "게시글 Id를 받아 게시글을 수정합니다.",
             security = @SecurityRequirement(name = "accessToken")
     )
-    @PatchMapping("/{postId}")
+    @PatchMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<PostCreateResponse> update(
             @Parameter(
                     description = "수정할 게시글의 ID입니다.",
@@ -151,7 +151,7 @@ public class PostController {
             @Parameter(
                     description = "수정할 게시글 데이터입니다."
             )
-            @RequestBody PostUpdateRequest postUpdateRequest
+            @ModelAttribute PostUpdateRequest postUpdateRequest
     ) {
         PostCreateResponse response = postCommandService.updatePost(SecurityUtils.getCurrentUserId(), postId, postUpdateRequest);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);

--- a/src/main/java/com/example/spot/web/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostUpdateRequest.java
@@ -33,6 +33,8 @@ public class PostUpdateRequest {
     )
     private String type;
 
+    private MultipartFile image;
+
     public Board getType() {
         return Board.findByValue(type);
     }

--- a/src/main/java/com/example/spot/web/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/example/spot/web/dto/post/PostUpdateRequest.java
@@ -6,11 +6,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#384 

<br/>

## 🔎 작업 내용

1. 게시글 수정 시, 이미지호 수정할 수 있도록 로직 구현 
2. `PostCommandServiceImpl` 내, `getImageUrls` 메서드 -> 재사용 가능 하도록 시그니처 변경

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
