### PR TITLE
[MODIFY] 게시글 조회 시 게시글 정렬 순서 변경 

### DIFF
--- a/src/main/java/com/example/spot/repository/PostRepository.java
+++ b/src/main/java/com/example/spot/repository/PostRepository.java
@@ -8,8 +8,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+    // 정렬
+     Page<Post> findByBoardAndPostReportListIsEmptyOrderByCreatedAtDesc(Board board, Pageable pageable);
     Page<Post> findByBoardAndPostReportListIsEmpty(Board board, Pageable pageable);
 
+    // 정렬 조건 필요
+    Page<Post> findByPostReportListIsEmptyOrderByCreatedAtDesc(Pageable pageable);
     Page<Post> findByPostReportListIsEmpty(Pageable pageable); // 모든 게시글 조회
 
 }

--- a/src/main/java/com/example/spot/service/post/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/post/PostQueryServiceImpl.java
@@ -101,10 +101,10 @@ public class PostQueryServiceImpl implements PostQueryService {
         Page<Post> postPage;
         if (boardType == Board.ALL) {
             // ALL 타입일 경우 모든 게시글 조회
-            postPage = postRepository.findByPostReportListIsEmpty(pageable);
+            postPage = postRepository.findByPostReportListIsEmptyOrderByCreatedAtDesc(pageable);
         } else {
             // 특정 게시판 타입의 게시글 조회
-            postPage = postRepository.findByBoardAndPostReportListIsEmpty(boardType, pageable);
+            postPage = postRepository.findByBoardAndPostReportListIsEmptyOrderByCreatedAtDesc(boardType, pageable);
         }
 
         // PostPagingDetailResponse를 묶어서 응답 리스트 생성 (좋아요 수, 좋아요여부, 스크랩 수, 스크랩여부 포함)

--- a/src/test/java/com/example/spot/service/post/PostQueryServiceTest.java
+++ b/src/test/java/com/example/spot/service/post/PostQueryServiceTest.java
@@ -266,7 +266,7 @@ class PostQueryServiceTest {
         List<Post> posts = List.of(post1, post2);
         postPage = new PageImpl<>(posts, pageable, 2);
 
-        when(postRepository.findByPostReportListIsEmpty(pageable)).thenReturn(postPage);
+        when(postRepository.findByPostReportListIsEmptyOrderByCreatedAtDesc(pageable)).thenReturn(postPage);
 
         // when
         PostPagingResponse result = postQueryService.getPagingPosts("ALL", pageable);
@@ -292,7 +292,7 @@ class PostQueryServiceTest {
         List<Post> posts = List.of(post2);
         postPage = new PageImpl<>(posts, pageable, 1);
 
-        when(postRepository.findByBoardAndPostReportListIsEmpty(Board.INFORMATION_SHARING, pageable)).thenReturn(postPage);
+        when(postRepository.findByBoardAndPostReportListIsEmptyOrderByCreatedAtDesc(Board.INFORMATION_SHARING, pageable)).thenReturn(postPage);
 
         // when
         PostPagingResponse result = postQueryService.getPagingPosts("INFORMATION_SHARING", pageable);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#387 

<br/>

## 🔎 작업 내용

1. 게시글 조회 시, 최신 게시글이 먼저 & 오래된 게시글이 뒤로 오도록 게시글 정렬 순서 변경

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
