### PR TITLE
[MODIFY] 소셜 로그인 시, 반환되는 `isSpotMember` 판단 기준 변경

### DIFF
--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -7,6 +7,9 @@ import com.example.spot.api.exception.handler.MemberHandler;
 import com.example.spot.domain.Member;
 import com.example.spot.domain.auth.RsaKey;
 import com.example.spot.repository.MemberStudyRepository;
+import com.example.spot.repository.MemberThemeRepository;
+import com.example.spot.repository.PreferredRegionRepository;
+import com.example.spot.repository.StudyReasonRepository;
 import com.example.spot.web.dto.rsa.Rsa;
 import com.example.spot.domain.auth.RefreshToken;
 import com.example.spot.domain.auth.VerificationCode;
@@ -66,6 +69,10 @@ public class AuthServiceImpl implements AuthService{
     private final MemberStudyRepository memberStudyRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final VerificationCodeRepository verificationCodeRepository;
+
+    private final MemberThemeRepository memberThemeRepository;
+    private final PreferredRegionRepository preferredRegionRepository;
+    private final StudyReasonRepository studyReasonRepository;
 
     private final MailService mailService;
     private final NaverOAuthService naverOAuthService;
@@ -263,6 +270,10 @@ public class AuthServiceImpl implements AuthService{
         Member member = memberRepository.findByEmailAndLoginType(email, LoginType.NAVER)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
 
+        if (!isMemberExistsByCheckList(member)) {
+            isSpotMember = Boolean.FALSE;
+        }
+
         // 로그인을 위한 토큰 발급
         TokenDTO token = jwtTokenProvider.createToken(member.getId());
         saveRefreshToken(member, token);
@@ -275,6 +286,13 @@ public class AuthServiceImpl implements AuthService{
                 .build();
 
         return SocialLoginSignInDTO.toDTO(isSpotMember, signInDTO);
+    }
+
+    public boolean isMemberExistsByCheckList(Member member) {
+        Long memberId = member.getId();
+        return memberThemeRepository.existsByMemberId(memberId) &&
+                preferredRegionRepository.existsByMemberId(memberId) &&
+                studyReasonRepository.existsByMemberId(memberId);
     }
 
     /**

--- a/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/spot/service/member/MemberServiceImpl.java
@@ -111,7 +111,10 @@ public class MemberServiceImpl implements MemberService {
 
             updateMemberProfileImage(member, kaKaoUser);
 
-            isSpotMember = true;
+            if (isMemberExistsByCheckList(member)) {
+                isSpotMember = true;
+            }
+
             // JWT 토큰 생성
             TokenDTO token = jwtTokenProvider.createToken(member.getId());
 
@@ -322,7 +325,9 @@ public class MemberServiceImpl implements MemberService {
 
                 saveRefreshToken(member, token);
 
-                isSpotMember = true;
+                if (isMemberExistsByCheckList(member)) {
+                    isSpotMember = true;
+                }
 
                 // 로그인 DTO 반환
                 MemberSignInDTO memberSignInDto = MemberSignInDTO.builder()
@@ -673,6 +678,14 @@ public class MemberServiceImpl implements MemberService {
             throw new UsernameNotFoundException("Invalid user ID format");
         }
     }
+
+    public boolean isMemberExistsByCheckList(Member member) {
+        Long memberId = member.getId();
+        return memberThemeRepository.existsByMemberId(memberId) &&
+                preferredRegionRepository.existsByMemberId(memberId) &&
+                studyReasonRepository.existsByMemberId(memberId);
+    }
+
 
     @Override
     @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#394 

<br/>

## 🔎 작업 내용

- 소셜 로그인 시, 반환되는 `isSpotMember`의 판단 기준을 변경합니다.
- 기존 회원가입 유무로 판단하여 응답 했지만, 앞으로는 체크리스트 입력 유무를 통해 판단하여 응답합니다.
- 네이버 로그인은 시루님이 한 번 확인 해주시면 감사하겠습니다..! 

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
