### PR TITLE
[MODIFY] 스터디 게시글 이미지 수정 로직 변경

### DIFF
--- a/src/main/java/com/example/spot/domain/mapping/StudyPostImage.java
+++ b/src/main/java/com/example/spot/domain/mapping/StudyPostImage.java
@@ -16,14 +16,17 @@ import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
+@Builder
 @DynamicUpdate
 @DynamicInsert
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StudyPostImage extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(nullable = false)
     private String url;
 
@@ -31,10 +34,4 @@ public class StudyPostImage extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_post_id", nullable = false)
     private StudyPost studyPost;
-
-/* ----------------------------- 생성자 ------------------------------------- */
-
-    public StudyPostImage(String url) {
-        this.url = url;
-    }
 }

--- a/src/main/java/com/example/spot/domain/study/StudyPost.java
+++ b/src/main/java/com/example/spot/domain/study/StudyPost.java
@@ -107,10 +107,6 @@ public class StudyPost extends BaseEntity {
         likedPosts.remove(likedPost);
     }
 
-    public void updateImage(StudyPostImage studyPostImage) {
-        images.set(images.indexOf(studyPostImage), studyPostImage);
-    }
-
     public void updateComment(StudyPostComment studyPostComment) {
         comments.set(comments.indexOf(studyPostComment), studyPostComment);
     }
@@ -151,5 +147,9 @@ public class StudyPost extends BaseEntity {
 
         member.updateStudyPost(this);
         study.updateStudyPost(this);
+    }
+
+    public void updateImage(StudyPostImage studyPostImage) {
+        images.set(images.indexOf(studyPostImage), studyPostImage);
     }
 }

--- a/src/main/java/com/example/spot/web/controller/StudyPostController.java
+++ b/src/main/java/com/example/spot/web/controller/StudyPostController.java
@@ -54,9 +54,6 @@ public class StudyPostController {
     public ApiResponse<StudyPostResDTO.PostPreviewDTO> createPost(
             @PathVariable @ExistStudy Long studyId,
             @ModelAttribute(name = "post") @Valid StudyPostRequestDTO.PostDTO postRequestDTO) {
-        if (postRequestDTO.getImages() == null) {
-            postRequestDTO.initImages();
-        }
         StudyPostResDTO.PostPreviewDTO postPreviewDTO = studyPostCommandService.createPost(studyId, postRequestDTO);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_POST_CREATED, postPreviewDTO);
     }
@@ -74,9 +71,6 @@ public class StudyPostController {
             @PathVariable @ExistStudyPost Long postId,
             @ModelAttribute(name= "post") @Valid StudyPostRequestDTO.PostDTO postDTO
     ) {
-        if (postDTO.getImages() == null) {
-            postDTO.initImages();
-        }
         StudyPostResDTO.PostPreviewDTO postPreviewDTO = studyPostCommandService.updatePost(studyId, postId, postDTO);
         return ApiResponse.onSuccess(SuccessStatus._STUDY_POST_UPDATED, postPreviewDTO);
     }

--- a/src/main/java/com/example/spot/web/dto/memberstudy/request/StudyPostRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/request/StudyPostRequestDTO.java
@@ -38,12 +38,11 @@ public class StudyPostRequestDTO {
         @Schema(description = "내용", example = "content")
         private String content;
 
-        @Schema(description = "이미지")
-        private List<MultipartFile> images;
+        @Schema(description = "신규 이미지")
+        private MultipartFile image;
 
-        public void initImages() {
-            this.images = new ArrayList<>();
-        }
+        @Schema(description = "기존 이미지")
+        private String existingImage;
 
     }
 }

--- a/src/test/java/com/example/spot/service/studypost/StudyPostCommandServiceTest.java
+++ b/src/test/java/com/example/spot/service/studypost/StudyPostCommandServiceTest.java
@@ -13,6 +13,7 @@ import com.example.spot.domain.study.Study;
 import com.example.spot.domain.study.StudyPost;
 import com.example.spot.domain.study.StudyPostComment;
 import com.example.spot.repository.*;
+import com.example.spot.service.s3.S3ImageService;
 import com.example.spot.web.dto.memberstudy.request.StudyPostCommentRequestDTO;
 import com.example.spot.web.dto.memberstudy.request.StudyPostRequestDTO;
 import com.example.spot.web.dto.memberstudy.response.StudyPostCommentResponseDTO;
@@ -30,6 +31,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,6 +71,9 @@ class StudyPostCommandServiceTest {
 
     @Mock
     private NotificationRepository notificationRepository;
+
+    @Mock
+    private S3ImageService s3ImageService;
 
     @InjectMocks
     private StudyPostCommandServiceImpl studyPostCommandService;
@@ -125,11 +130,14 @@ class StudyPostCommandServiceTest {
         when(studyLikedPostRepository.existsByMemberIdAndStudyPostId(3L, 1L))
                 .thenReturn(true);
 
-        // Comment
+         // Comment
         when(studyPostCommentRepository.findAllByStudyPostId(1L))
                 .thenReturn(List.of(studyPost1Comment1, studyPost1Comment2));
         when(studyPostCommentRepository.findById(1L)).thenReturn(Optional.of(studyPost1Comment1));
         when(studyPostCommentRepository.findById(2L)).thenReturn(Optional.of(studyPost1Comment2));
+
+        // S3
+        when(s3ImageService.upload(any(MultipartFile.class))).thenReturn("url");
 
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 
- #399 
- SPOT-259

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.
- 게시글 작성 API, 게시글 수정 API Request DTO 변경
  (두 API가 같은 DTO를 사용하고 있어서 두 가지 모두 바뀌었습니다!)
- 게시글 작성 API 오류 해결
- 게시글 수정 시 기존 이미지와 신규 이미지 로직을 분리하여 처리하도록 변경

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
