### PR TITLE
[MODIFY] 스터디 게시글 목록 조회 시 전체 페이지 수 반환

### DIFF
--- a/src/main/java/com/example/spot/repository/StudyPostRepository.java
+++ b/src/main/java/com/example/spot/repository/StudyPostRepository.java
@@ -1,5 +1,6 @@
 package com.example.spot.repository;
 
+import com.example.spot.domain.enums.Theme;
 import com.example.spot.domain.study.StudyPost;
 
 import java.util.Arrays;
@@ -20,5 +21,9 @@ public interface StudyPostRepository extends JpaRepository<StudyPost, Long>, Stu
 
     Optional<StudyPost> findByIdAndMemberId(Long postId, Long memberId);
 
-    List<StudyPost> findAllByStudyIdAndIsAnnouncement(Long studyId, Boolean isAnnouncement, PageRequest pageRequest);
+    Long countByStudyId(Long studyId);
+
+    Long countByStudyIdAndIsAnnouncement(Long studyId, Boolean aTrue);
+
+    Long countByStudyIdAndTheme(Long studyId, Theme theme);
 }

--- a/src/main/java/com/example/spot/repository/querydsl/StudyPostRepositoryCustom.java
+++ b/src/main/java/com/example/spot/repository/querydsl/StudyPostRepositoryCustom.java
@@ -2,11 +2,15 @@ package com.example.spot.repository.querydsl;
 
 import com.example.spot.domain.enums.Theme;
 import com.example.spot.domain.study.StudyPost;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface StudyPostRepositoryCustom {
+
+    // 스터디 공지 게시글 페이징 조회
+    List<StudyPost> findAnnouncementsByStudyId(Long studyId, Pageable pageable);
 
     // 테마별 스터디 게시글 페이징 조회
     List<StudyPost> findAllByStudyIdAndTheme(Long studyId, Theme theme, Pageable pageable);

--- a/src/main/java/com/example/spot/repository/querydsl/impl/StudyPostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/spot/repository/querydsl/impl/StudyPostRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.example.spot.repository.querydsl.StudyPostRepositoryCustom;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -15,6 +16,18 @@ import java.util.List;
 public class StudyPostRepositoryCustomImpl implements StudyPostRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StudyPost> findAnnouncementsByStudyId(Long studyId, Pageable pageable) {
+        QStudyPost studyPost = QStudyPost.studyPost;
+        return queryFactory.selectFrom(studyPost)
+                .where(studyPost.study.id.eq(studyId))
+                .where(studyPost.isAnnouncement.eq(true))
+                .orderBy(studyPost.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
 
     @Override
     public List<StudyPost> findAllByStudyIdAndTheme(Long studyId, Theme theme, Pageable pageable) {

--- a/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostResDTO.java
+++ b/src/main/java/com/example/spot/web/dto/memberstudy/response/StudyPostResDTO.java
@@ -36,19 +36,13 @@ public class StudyPostResDTO {
     }
 
     @Getter
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    @Builder(access = AccessLevel.PRIVATE)
+    @RequiredArgsConstructor
+    @Builder
     public static class PostListDTO {
 
         private final Long studyId;
         private final List<PostDTO> posts;
-
-        public static PostListDTO toDTO(Study study, List<PostDTO> postDTOS) {
-            return PostListDTO.builder()
-                    .studyId(study.getId())
-                    .posts(postDTOS)
-                    .build();
-        }
+        private final Long totalPages;
     }
 
     @Getter

--- a/src/test/java/com/example/spot/service/studypost/StudyPostQueryServiceTest.java
+++ b/src/test/java/com/example/spot/service/studypost/StudyPostQueryServiceTest.java
@@ -137,7 +137,7 @@ class StudyPostQueryServiceTest {
         pageRequest = PageRequest.of(0, 10);
         when(studyPostRepository.findAllByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost2, studyPost3));
-        when(studyPostRepository.findAllByStudyIdAndIsAnnouncement(studyId, true, pageRequest))
+        when(studyPostRepository.findAnnouncementsByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost2));
         when(studyPostRepository.findAllByStudyIdAndTheme(studyId, Theme.FREE_TALK, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost3));
@@ -166,7 +166,7 @@ class StudyPostQueryServiceTest {
         pageRequest = PageRequest.of(0, 10);
         when(studyPostRepository.findAllByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost2, studyPost3));
-        when(studyPostRepository.findAllByStudyIdAndIsAnnouncement(studyId, true, pageRequest))
+        when(studyPostRepository.findAnnouncementsByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost2));
         when(studyPostRepository.findAllByStudyIdAndTheme(studyId, Theme.FREE_TALK, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost3));
@@ -195,7 +195,7 @@ class StudyPostQueryServiceTest {
         pageRequest = PageRequest.of(0, 10);
         when(studyPostRepository.findAllByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost2, studyPost3));
-        when(studyPostRepository.findAllByStudyIdAndIsAnnouncement(studyId, true, pageRequest))
+        when(studyPostRepository.findAnnouncementsByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost2));
         when(studyPostRepository.findAllByStudyIdAndTheme(studyId, Theme.FREE_TALK, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost3));
@@ -224,7 +224,7 @@ class StudyPostQueryServiceTest {
         pageRequest = PageRequest.of(0, 10);
         when(studyPostRepository.findAllByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost2, studyPost3));
-        when(studyPostRepository.findAllByStudyIdAndIsAnnouncement(studyId, true, pageRequest))
+        when(studyPostRepository.findAnnouncementsByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost2));
         when(studyPostRepository.findAllByStudyIdAndTheme(studyId, Theme.FREE_TALK, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost3));
@@ -246,7 +246,7 @@ class StudyPostQueryServiceTest {
         pageRequest = PageRequest.of(0, 10);
         when(studyPostRepository.findAllByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost2, studyPost3));
-        when(studyPostRepository.findAllByStudyIdAndIsAnnouncement(studyId, true, pageRequest))
+        when(studyPostRepository.findAnnouncementsByStudyId(studyId, pageRequest))
                 .thenReturn(List.of(studyPost2));
         when(studyPostRepository.findAllByStudyIdAndTheme(studyId, Theme.FREE_TALK, pageRequest))
                 .thenReturn(List.of(studyPost1, studyPost3));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈 번호, #이슈 링크 
- #406 
- SPOT-262

<br/>

## 🔎 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.
- 스터디 게시글 페이징 조회 시 전체 페이지 수 반환
- totalPages = 3인 경우 -> offset 요청 파라미터 값으로 0, 1, 2 유효 (3부터는 빈 리스트 반환)

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 제가 지난주 대면 회의에 못 가서 요청하신 부분이 정확히 요게 맞는지 잘 모르겠네요...!! 확인 부탁드립니당
