### PR TITLE
[FEAT] 닉네임 중복 확인 API 구현

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
@@ -32,6 +32,7 @@ public enum SuccessStatus implements BaseCode {
     _MEMBER_EMAIL_CHECK_COMPLETED(HttpStatus.OK, "MEMBER2013", "회원 이메일 사용 가능 여부 조회 완료"),
     _RSA_PUBLIC_KEY_FOUND(HttpStatus.OK, "MEMBER2014", "RSA Public Key 조회 완료"),
     _MEMBER_SIGNUP_CHECK_COMPLETED(HttpStatus.OK, "MEMBER2015", "회원 가입 유무 조회 완료"),
+    _MEMBER_NICKNAME_CHECK_COMPLETED(HttpStatus.NO_CONTENT, "MEMBER2016", "회원 닉네임 사용 가능 여부 조회 완료"),
 
     //스터디 게시글 관련 응답
     _STUDY_POST_CREATED(HttpStatus.CREATED, "STUDYPOST3001", "스터디 게시글 작성 완료"),

--- a/src/main/java/com/example/spot/repository/MemberRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberRepository.java
@@ -15,6 +15,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByNickname(String nickname);
+
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByLoginId(String loginId);

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.spot.service.auth;
 
+import com.example.spot.web.dto.member.MemberRequestDTO.SignUpDetailDTO;
 import com.example.spot.web.dto.rsa.Rsa;
 import com.example.spot.web.dto.member.MemberRequestDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO;
@@ -16,7 +17,7 @@ public interface AuthService {
     // 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급
     TokenDTO reissueToken(String refreshToken);
 
-    MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(String nickname, Boolean personalInfo, Boolean idInfo);
+    MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(SignUpDetailDTO sign);
 
     MemberResponseDTO.InactiveMemberDTO withdraw();
 

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -45,4 +45,6 @@ public interface AuthService {
     MemberResponseDTO.AvailabilityDTO checkEmailAvailability(String email);
 
     MemberResponseDTO.CheckMemberDTO checkIsSpotMember(Long loginId);
+
+    MemberResponseDTO.NicknameDuplicateDTO checkNicknameAvailability(String nickname);
 }

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -684,11 +684,8 @@ public class AuthServiceImpl implements AuthService{
 
     @Override
     public NicknameDuplicateDTO checkNicknameAvailability(String nickname) {
-        if (!memberRepository.existsByNickname(nickname)) {
-            return new NicknameDuplicateDTO(nickname, Boolean.FALSE);
-        } else {
-            return new NicknameDuplicateDTO(nickname, Boolean.TRUE);
-        }
+        boolean isDuplicate = memberRepository.existsByNickname(nickname);
+        return new NicknameDuplicateDTO(nickname, isDuplicate);
     }
 
     /**

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.spot.repository.MemberStudyRepository;
 import com.example.spot.repository.MemberThemeRepository;
 import com.example.spot.repository.PreferredRegionRepository;
 import com.example.spot.repository.StudyReasonRepository;
+import com.example.spot.web.dto.member.MemberRequestDTO.SignUpDetailDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.CheckMemberDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.NicknameDuplicateDTO;
 import com.example.spot.web.dto.rsa.Rsa;
@@ -138,15 +139,15 @@ public class AuthServiceImpl implements AuthService{
 /* ----------------------------- 공통 회원 관리 API ------------------------------------- */
 
     @Override
-    public MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(String nickname, Boolean personalInfo, Boolean idInfo) {
+    public MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(SignUpDetailDTO request) {
 
         // Authorization
         Long memberId = SecurityUtils.getCurrentUserId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
-        member.setNickname(nickname);
-        member.updateTerm(personalInfo, idInfo);
+        member.setNickname(request.getNickname());
+        member.updateTerm(request.getPersonalInfo(), request.getIdInfo());
         member = memberRepository.save(member);
 
         return MemberResponseDTO.MemberInfoCreationDTO.toDTO(member);

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.spot.repository.MemberThemeRepository;
 import com.example.spot.repository.PreferredRegionRepository;
 import com.example.spot.repository.StudyReasonRepository;
 import com.example.spot.web.dto.member.MemberResponseDTO.CheckMemberDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.NicknameDuplicateDTO;
 import com.example.spot.web.dto.rsa.Rsa;
 import com.example.spot.domain.auth.RefreshToken;
 import com.example.spot.domain.auth.VerificationCode;
@@ -679,6 +680,15 @@ public class AuthServiceImpl implements AuthService{
         boolean memberExistsByCheckList = isMemberExistsByCheckList(member);
 
         return CheckMemberDTO.toDTO(memberExistsByCheckList);
+    }
+
+    @Override
+    public NicknameDuplicateDTO checkNicknameAvailability(String nickname) {
+        if (!memberRepository.existsByNickname(nickname)) {
+            return new NicknameDuplicateDTO(nickname, Boolean.FALSE);
+        } else {
+            return new NicknameDuplicateDTO(nickname, Boolean.TRUE);
+        }
     }
 
     /**

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.spot.web.controller;
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
 import com.example.spot.security.utils.SecurityUtils;
+import com.example.spot.web.dto.member.MemberResponseDTO.NicknameDuplicateDTO;
 import com.example.spot.web.dto.rsa.Rsa;
 import com.example.spot.service.auth.AuthService;
 import com.example.spot.validation.annotation.TextLength;
@@ -48,6 +49,23 @@ public class AuthController {
     }
 
 /* ----------------------------- 공통 회원 관리 API ------------------------------------- */
+
+    // 닉네임 중복 확인
+    @Tag(name = "회원 관리 API - 개발 완료", description = "회원 관리 API")
+    @Operation(summary = "[공통 회원 관리] 닉네임 중복 확인 API",
+            description = """
+            ## [공통 회원 관리] 닉네임 중복 확인 API입니다.
+            * Request Params : String nickname
+            * Response Body : Boolean isAvailable
+            
+            중복된 이메일이 존재하면 duplicate 필드가 true로 설정됩니다. 
+            """)
+    @GetMapping("/check/nickname")
+    public ApiResponse<NicknameDuplicateDTO> checkNicknameAvailability(
+            @RequestParam @TextLength(max = 8) String nickname) {
+        NicknameDuplicateDTO nicknameDuplicateDTO = authService.checkNicknameAvailability(nickname);
+        return ApiResponse.onSuccess(SuccessStatus._MEMBER_NICKNAME_CHECK_COMPLETED, nicknameDuplicateDTO);
+    }
 
     @Tag(name = "회원 관리 API - 개발 완료", description = "회원 관리 API")
     @Operation(summary = "[공통 회원 관리] 닉네임 생성 및 약관 동의 API",

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -77,10 +77,8 @@ public class AuthController {
             """)
     @PostMapping("/sign-up/update")
     public ApiResponse<MemberResponseDTO.MemberInfoCreationDTO> signUpAndPartialUpdate(
-            @RequestParam @TextLength(max = 8) String nickname,
-            @RequestParam Boolean personalInfo,
-            @RequestParam Boolean idInfo) {
-        MemberResponseDTO.MemberInfoCreationDTO memberInfoCreationDTO = authService.signUpAndPartialUpdate(nickname, personalInfo, idInfo);
+            @RequestBody MemberRequestDTO.SignUpDetailDTO signUpDetailDTO) {
+        MemberResponseDTO.MemberInfoCreationDTO memberInfoCreationDTO = authService.signUpAndPartialUpdate(signUpDetailDTO);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_UPDATED, memberInfoCreationDTO);
     }
 

--- a/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
@@ -23,6 +23,14 @@ public class MemberRequestDTO {
     }
 
     @Getter
+    @RequiredArgsConstructor
+    public static class SignUpDetailDTO {
+        String nickname;
+        Boolean personalInfo;
+        Boolean idInfo;
+    }
+
+    @Getter
     @Builder
     @RequiredArgsConstructor
     public static class SignUpDTO {

--- a/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
@@ -218,5 +218,16 @@ public class MemberResponseDTO {
         }
     }
 
+    @Getter
+    public static class NicknameDuplicateDTO {
+        private final String nickname;
+        private final boolean isDuplicate;
+
+        public NicknameDuplicateDTO(String nickname, boolean isDuplicate) {
+            this.nickname = nickname;
+            this.isDuplicate = isDuplicate;
+        }
+    }
+
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#409 

<br/>

## 🔎 작업 내용

1. 닉네임 중복 확인 API 구현 
2. 닉네임 생성 및 약관 동의 API 호출 시, Request Body로 요청 값 받도록 변경 (안드로이드 요청)
<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
