### PR TITLE
[FEAT] 스터디 조회 시 활동비 필터링을 단일값에서 범위 조건으로 확장

### DIFF
--- a/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/ErrorStatus.java
@@ -29,7 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _MEMBER_EMAIL_EXIST(HttpStatus.BAD_REQUEST, "COMMON4014", "이미 가입 된 이메일입니다. 다른 로그인 방식을 이용해주세요."),
     _RSA_ERROR(HttpStatus.BAD_REQUEST, "COMMON4015", "RSA 에러가 발생했습니다."),
     _NOT_ADMIN(HttpStatus.FORBIDDEN, "COMMON4016", "관리자 권한이 없습니다."),
-
+    _INVALID_ENUM_VALUE(HttpStatus.BAD_REQUEST, "COMMON4017", "유효하지 않은 Enum 값입니다."),
     // 네이버 소셜 로그인 관련 에러
     _NAVER_SIGN_IN_INTEGRATION_FAILED(HttpStatus.UNAUTHORIZED, "NAVER4001", "네이버 로그인 연동에 실패하였습니다."),
     _NAVER_ACCESS_TOKEN_ISSUANCE_FAILED(HttpStatus.UNAUTHORIZED, "NAVER4002", "네이버 액세스 토큰 발급에 실패하였습니다."),

--- a/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
+++ b/src/main/java/com/example/spot/api/code/status/SuccessStatus.java
@@ -32,6 +32,7 @@ public enum SuccessStatus implements BaseCode {
     _MEMBER_EMAIL_CHECK_COMPLETED(HttpStatus.OK, "MEMBER2013", "회원 이메일 사용 가능 여부 조회 완료"),
     _RSA_PUBLIC_KEY_FOUND(HttpStatus.OK, "MEMBER2014", "RSA Public Key 조회 완료"),
     _MEMBER_SIGNUP_CHECK_COMPLETED(HttpStatus.OK, "MEMBER2015", "회원 가입 유무 조회 완료"),
+    _MEMBER_NICKNAME_CHECK_COMPLETED(HttpStatus.NO_CONTENT, "MEMBER2016", "회원 닉네임 사용 가능 여부 조회 완료"),
 
     //스터디 게시글 관련 응답
     _STUDY_POST_CREATED(HttpStatus.CREATED, "STUDYPOST3001", "스터디 게시글 작성 완료"),

--- a/src/main/java/com/example/spot/repository/MemberRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberRepository.java
@@ -15,6 +15,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByNickname(String nickname);
+
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByLoginId(String loginId);

--- a/src/main/java/com/example/spot/repository/querydsl/impl/StudyRepositoryCustomImpl.java
+++ b/src/main/java/com/example/spot/repository/querydsl/impl/StudyRepositoryCustomImpl.java
@@ -423,8 +423,11 @@ SELECT id FROM study WHERE MATCH(title) AGAINST (:keyword IN NATURAL LANGUAGE MO
         if (search.get("hasFee") != null) {
             builder.and(study.hasFee.eq((Boolean) search.get("hasFee")));
         }
-        if (search.get("fee") != null) {
-            builder.and(study.fee.loe((Integer) search.get("fee")));
+        if (search.get("maxFee") != null) {
+            builder.and(study.fee.loe((Integer) search.get("maxFee")));
+        }
+        if (search.get("minFee") != null) {
+            builder.and(study.fee.goe((Integer) search.get("minFee")));
         }
         if (search.get("themeTypes") != null) {
             List<ThemeType> themeTypes = (List<ThemeType>) search.get("themeTypes");

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.spot.service.auth;
 
+import com.example.spot.web.dto.member.MemberRequestDTO.SignUpDetailDTO;
 import com.example.spot.web.dto.rsa.Rsa;
 import com.example.spot.web.dto.member.MemberRequestDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO;
@@ -16,7 +17,7 @@ public interface AuthService {
     // 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급
     TokenDTO reissueToken(String refreshToken);
 
-    MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(String nickname, Boolean personalInfo, Boolean idInfo);
+    MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(SignUpDetailDTO sign);
 
     MemberResponseDTO.InactiveMemberDTO withdraw();
 

--- a/src/main/java/com/example/spot/service/auth/AuthService.java
+++ b/src/main/java/com/example/spot/service/auth/AuthService.java
@@ -45,4 +45,6 @@ public interface AuthService {
     MemberResponseDTO.AvailabilityDTO checkEmailAvailability(String email);
 
     MemberResponseDTO.CheckMemberDTO checkIsSpotMember(Long loginId);
+
+    MemberResponseDTO.NicknameDuplicateDTO checkNicknameAvailability(String nickname);
 }

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -684,11 +684,8 @@ public class AuthServiceImpl implements AuthService{
 
     @Override
     public NicknameDuplicateDTO checkNicknameAvailability(String nickname) {
-        if (!memberRepository.existsByNickname(nickname)) {
-            return new NicknameDuplicateDTO(nickname, Boolean.FALSE);
-        } else {
-            return new NicknameDuplicateDTO(nickname, Boolean.TRUE);
-        }
+        boolean isDuplicate = memberRepository.existsByNickname(nickname);
+        return new NicknameDuplicateDTO(nickname, isDuplicate);
     }
 
     /**

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.spot.repository.MemberStudyRepository;
 import com.example.spot.repository.MemberThemeRepository;
 import com.example.spot.repository.PreferredRegionRepository;
 import com.example.spot.repository.StudyReasonRepository;
+import com.example.spot.web.dto.member.MemberRequestDTO.SignUpDetailDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.CheckMemberDTO;
 import com.example.spot.web.dto.member.MemberResponseDTO.NicknameDuplicateDTO;
 import com.example.spot.web.dto.rsa.Rsa;
@@ -138,15 +139,15 @@ public class AuthServiceImpl implements AuthService{
 /* ----------------------------- 공통 회원 관리 API ------------------------------------- */
 
     @Override
-    public MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(String nickname, Boolean personalInfo, Boolean idInfo) {
+    public MemberResponseDTO.MemberInfoCreationDTO signUpAndPartialUpdate(SignUpDetailDTO request) {
 
         // Authorization
         Long memberId = SecurityUtils.getCurrentUserId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 
-        member.setNickname(nickname);
-        member.updateTerm(personalInfo, idInfo);
+        member.setNickname(request.getNickname());
+        member.updateTerm(request.getPersonalInfo(), request.getIdInfo());
         member = memberRepository.save(member);
 
         return MemberResponseDTO.MemberInfoCreationDTO.toDTO(member);

--- a/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/spot/service/auth/AuthServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.spot.repository.MemberThemeRepository;
 import com.example.spot.repository.PreferredRegionRepository;
 import com.example.spot.repository.StudyReasonRepository;
 import com.example.spot.web.dto.member.MemberResponseDTO.CheckMemberDTO;
+import com.example.spot.web.dto.member.MemberResponseDTO.NicknameDuplicateDTO;
 import com.example.spot.web.dto.rsa.Rsa;
 import com.example.spot.domain.auth.RefreshToken;
 import com.example.spot.domain.auth.VerificationCode;
@@ -679,6 +680,15 @@ public class AuthServiceImpl implements AuthService{
         boolean memberExistsByCheckList = isMemberExistsByCheckList(member);
 
         return CheckMemberDTO.toDTO(memberExistsByCheckList);
+    }
+
+    @Override
+    public NicknameDuplicateDTO checkNicknameAvailability(String nickname) {
+        if (!memberRepository.existsByNickname(nickname)) {
+            return new NicknameDuplicateDTO(nickname, Boolean.FALSE);
+        } else {
+            return new NicknameDuplicateDTO(nickname, Boolean.TRUE);
+        }
     }
 
     /**

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -880,8 +880,10 @@ public class StudyQueryServiceImpl implements StudyQueryService {
             search.put("isOnline", request.getIsOnline());
         if (request.getHasFee() != null)
             search.put("hasFee", request.getHasFee());
-        if (request.getFee() != null)
-            search.put("fee", request.getFee());
+        if (request.getMaxFee() != null)
+            search.put("maxFee", request.getMaxFee());
+        if (request.getMinFee() != null)
+            search.put("minFee", request.getMinFee());
         return search;
     }
 
@@ -906,8 +908,10 @@ public class StudyQueryServiceImpl implements StudyQueryService {
             search.put("isOnline", request.getIsOnline());
         if (request.getHasFee() != null)
             search.put("hasFee", request.getHasFee());
-        if (request.getFee() != null)
-            search.put("fee", request.getFee());
+        if (request.getMaxFee() != null)
+            search.put("maxFee", request.getMaxFee());
+        if (request.getMinFee() != null)
+            search.put("minFee", request.getMinFee());
 
         if (request.getThemeTypes() != null && !request.getThemeTypes().isEmpty()) {
             search.put("themeTypes", request.getThemeTypes());

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.spot.web.controller;
 import com.example.spot.api.ApiResponse;
 import com.example.spot.api.code.status.SuccessStatus;
 import com.example.spot.security.utils.SecurityUtils;
+import com.example.spot.web.dto.member.MemberResponseDTO.NicknameDuplicateDTO;
 import com.example.spot.web.dto.rsa.Rsa;
 import com.example.spot.service.auth.AuthService;
 import com.example.spot.validation.annotation.TextLength;
@@ -48,6 +49,23 @@ public class AuthController {
     }
 
 /* ----------------------------- 공통 회원 관리 API ------------------------------------- */
+
+    // 닉네임 중복 확인
+    @Tag(name = "회원 관리 API - 개발 완료", description = "회원 관리 API")
+    @Operation(summary = "[공통 회원 관리] 닉네임 중복 확인 API",
+            description = """
+            ## [공통 회원 관리] 닉네임 중복 확인 API입니다.
+            * Request Params : String nickname
+            * Response Body : Boolean isAvailable
+            
+            중복된 이메일이 존재하면 duplicate 필드가 true로 설정됩니다. 
+            """)
+    @GetMapping("/check/nickname")
+    public ApiResponse<NicknameDuplicateDTO> checkNicknameAvailability(
+            @RequestParam @TextLength(max = 8) String nickname) {
+        NicknameDuplicateDTO nicknameDuplicateDTO = authService.checkNicknameAvailability(nickname);
+        return ApiResponse.onSuccess(SuccessStatus._MEMBER_NICKNAME_CHECK_COMPLETED, nicknameDuplicateDTO);
+    }
 
     @Tag(name = "회원 관리 API - 개발 완료", description = "회원 관리 API")
     @Operation(summary = "[공통 회원 관리] 닉네임 생성 및 약관 동의 API",

--- a/src/main/java/com/example/spot/web/controller/AuthController.java
+++ b/src/main/java/com/example/spot/web/controller/AuthController.java
@@ -77,10 +77,8 @@ public class AuthController {
             """)
     @PostMapping("/sign-up/update")
     public ApiResponse<MemberResponseDTO.MemberInfoCreationDTO> signUpAndPartialUpdate(
-            @RequestParam @TextLength(max = 8) String nickname,
-            @RequestParam Boolean personalInfo,
-            @RequestParam Boolean idInfo) {
-        MemberResponseDTO.MemberInfoCreationDTO memberInfoCreationDTO = authService.signUpAndPartialUpdate(nickname, personalInfo, idInfo);
+            @RequestBody MemberRequestDTO.SignUpDetailDTO signUpDetailDTO) {
+        MemberResponseDTO.MemberInfoCreationDTO memberInfoCreationDTO = authService.signUpAndPartialUpdate(signUpDetailDTO);
         return ApiResponse.onSuccess(SuccessStatus._MEMBER_UPDATED, memberInfoCreationDTO);
     }
 

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -130,7 +130,8 @@ public class SearchController {
     - maxAge: 60 이하의 정수 
     - isOnline: 스터디 온라인 진행 여부 (true, false)
     - hasFee: 스터디 활동비 유무 (true, false)
-    - fee: 스터디 최대 활동비 
+    - maxFee: 스터디 최대 활동비
+    - minFee: 스터디 최소 활동비
     """, required = false)
     @Parameter(name = "page", description = "조회할 페이지 번호를 입력 받습니다. 페이지 번호는 0부터 시작합니다.", required = true)
     @Parameter(name = "size", description = "조회할 페이지 크기를 입력 받습니다. 페이지 크기는 1 이상의 정수 입니다. ", required = true)
@@ -161,7 +162,8 @@ public class SearchController {
     - maxAge: 60 이하의 정수 
     - isOnline: 스터디 온라인 진행 여부 (true, false)
     - hasFee: 스터디 활동비 유무 (true, false)
-    - fee: 스터디 최대 활동비 
+    - maxFee: 스터디 최대 활동비
+    - minFee: 스터디 최소 활동비
     """, required = false)
     @Parameter(name = "theme", description = "조회할 관심 분야를 입력 받습니다.", required = true)
     @Parameter(name = "page", description = "조회할 페이지 번호를 입력 받습니다. 페이지 번호는 0부터 시작합니다.", required = true)
@@ -200,7 +202,8 @@ public class SearchController {
     - maxAge: 60 이하의 정수 
     - isOnline: 스터디 온라인 진행 여부 (true, false)
     - hasFee: 스터디 활동비 유무 (true, false)
-    - fee: 스터디 최대 활동비 
+    - maxFee: 스터디 최대 활동비
+    - minFee: 스터디 최소 활동비
     """, required = false)
     @Parameter(name = "page", description = "조회할 페이지 번호를 입력 받습니다. 페이지 번호는 0부터 시작합니다.", required = true)
     @Parameter(name = "size", description = "조회할 페이지 크기를 입력 받습니다. 페이지 크기는 1 이상의 정수 입니다. ", required = true)
@@ -232,7 +235,8 @@ public class SearchController {
     - maxAge: 60 이하의 정수 
     - isOnline: 스터디 온라인 진행 여부 (true, false)
     - hasFee: 스터디 활동비 유무 (true, false)
-    - fee: 스터디 최대 활동비 
+    - maxFee: 스터디 최대 활동비
+    - minFee: 스터디 최소 활동비
     """, required = false)
     @Parameter(name = "regionCode", description = "조회할 지역 코드를 입력 받습니다. 지역 코드는 10자리의 문자열 입니다. ex) 1111051500", required = true)
     @Parameter(name = "page", description = "조회할 페이지 번호를 입력 받습니다. 페이지 번호는 0부터 시작합니다.", required = true)
@@ -268,7 +272,8 @@ public class SearchController {
     - maxAge: 60 이하의 정수 
     - isOnline: 스터디 온라인 진행 여부 (true, false)
     - hasFee: 스터디 활동비 유무 (true, false)
-    - fee: 스터디 최대 활동비 
+    - maxFee: 스터디 최대 활동비
+    - minFee: 스터디 최소 활동비
     """, required = false)
     @Parameter(name = "page", description = "조회할 페이지 번호를 입력 받습니다. 페이지 번호는 0부터 시작합니다.", required = true)
     @Parameter(name = "size", description = "조회할 페이지 크기를 입력 받습니다. 페이지 크기는 1 이상의 정수 입니다. ", required = true)

--- a/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberRequestDTO.java
@@ -23,6 +23,14 @@ public class MemberRequestDTO {
     }
 
     @Getter
+    @RequiredArgsConstructor
+    public static class SignUpDetailDTO {
+        String nickname;
+        Boolean personalInfo;
+        Boolean idInfo;
+    }
+
+    @Getter
     @Builder
     @RequiredArgsConstructor
     public static class SignUpDTO {

--- a/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/member/MemberResponseDTO.java
@@ -218,5 +218,16 @@ public class MemberResponseDTO {
         }
     }
 
+    @Getter
+    public static class NicknameDuplicateDTO {
+        private final String nickname;
+        private final boolean isDuplicate;
+
+        public NicknameDuplicateDTO(String nickname, boolean isDuplicate) {
+            this.nickname = nickname;
+            this.isDuplicate = isDuplicate;
+        }
+    }
+
 }
 

--- a/src/main/java/com/example/spot/web/dto/search/BaseSearchRequestStudyDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/BaseSearchRequestStudyDTO.java
@@ -41,7 +41,11 @@ public class BaseSearchRequestStudyDTO {
 
     @Schema(description = "스터디 최대 활동비.", example = "10000")
     @Max(value = 1000000, message = "최대 활동비는 1,000,000원 입니다.")
-    private Integer fee;
+    private Integer maxFee;
+
+    @Schema(description = "스터디 최소 활동비.", example = "0")
+    @Min(value = 0, message = "최소 활동비는 0원 입니다.")
+    private Integer minFee;
 
     // 공통 검증 로직
     @AssertTrue(message = "최소 나이는 최대 나이보다 작아야 합니다.")
@@ -57,6 +61,6 @@ public class BaseSearchRequestStudyDTO {
         if (hasFee == null || hasFee) {
             return true;
         }
-        return fee == null;
+        return maxFee == null && minFee == null;
     }
 }

--- a/src/main/java/com/example/spot/web/dto/search/BaseSearchRequestStudyDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/BaseSearchRequestStudyDTO.java
@@ -63,4 +63,13 @@ public class BaseSearchRequestStudyDTO {
         }
         return maxFee == null && minFee == null;
     }
+
+    @AssertTrue(message = "최대 활동비는 최소 활동비보다 커야 합니다.")
+    private boolean isValidFeeRange() {
+        if (maxFee == null || minFee == null) {
+            return true;
+        }
+        return minFee <= maxFee;
+    }
+
 }

--- a/src/test/java/com/example/spot/service/study/StudyQueryServiceTest.java
+++ b/src/test/java/com/example/spot/service/study/StudyQueryServiceTest.java
@@ -1953,7 +1953,8 @@ class StudyQueryServiceTest {
         searchConditions.put("maxAge", 40);
         searchConditions.put("isOnline", true);
         searchConditions.put("hasFee", true);
-        searchConditions.put("fee", 10000);
+        searchConditions.put("maxFee", 10000);
+        searchConditions.put("minFee", 0);
         return searchConditions;
     }
 
@@ -1965,20 +1966,22 @@ class StudyQueryServiceTest {
         searchConditions.put("maxAge", 40);
         searchConditions.put("isOnline", true);
         searchConditions.put("hasFee", true);
-        searchConditions.put("fee", 10000);
+        searchConditions.put("maxFee", 10000);
+        searchConditions.put("minFee", 0);
         searchConditions.put("themeTypes", List.of(ThemeType.어학, ThemeType.공모전));
         return searchConditions;
     }
 
     private static SearchRequestStudyDTO getSearchRequestStudyDTO() {
         return SearchRequestStudyDTO.builder()
-            .gender(Gender.MALE)
-            .minAge(20)
-            .maxAge(40)
-            .fee(10000)
-            .isOnline(true)
-            .hasFee(true)
-            .build();
+                .gender(Gender.MALE)
+                .minAge(20)
+                .maxAge(40)
+                .maxFee(10000)
+                .minFee(0)
+                .isOnline(true)
+                .hasFee(true)
+                .build();
     }
 
     private static SearchRequestStudyWithThemeDTO getSearchRequestStudyWithThemeDTO() {
@@ -1986,7 +1989,8 @@ class StudyQueryServiceTest {
                 .gender(Gender.MALE)
                 .minAge(20)
                 .maxAge(40)
-                .fee(10000)
+                .maxFee(10000)
+                .minFee(0)
                 .isOnline(true)
                 .hasFee(true)
                 .themeTypes(List.of(ThemeType.어학, ThemeType.공모전))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#411
<br/>

## 🔎 작업 내용

1. 내 관심 지역, 관심 분야, 모집 중 스터디 조회 시, 활동비를 최댓값만 입력 받는게 아닌, 범위로 필터링 할 수 있도록 로직 확장

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
