### PR TITLE
[FEAT] 알림 조회 시, 알림이 발생한 지점으로 이동할 수 있도록 응답 값 추가

### DIFF
--- a/src/main/java/com/example/spot/domain/Notification.java
+++ b/src/main/java/com/example/spot/domain/Notification.java
@@ -37,6 +37,9 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private String notifierName;
 
+    @Column(nullable = true)
+    private Long studyPostId;
+
     //== 회원 ==//
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/example/spot/service/notification/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/notification/NotificationQueryServiceImpl.java
@@ -94,6 +94,7 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
                     .notificationId(notification.getId())
                     .createdAt(notification.getCreatedAt())
                     .type(notification.getType())
+                    .studyId(notification.getStudy().getId())
                     .studyTitle(notification.getStudy().getTitle())
                     .studyProfileImage(notification.getStudy().getProfileImage())
                     .notifierName(notification.getNotifierName()) // 알림 생성한 회원 이름

--- a/src/main/java/com/example/spot/service/notification/NotificationQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/notification/NotificationQueryServiceImpl.java
@@ -95,6 +95,7 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
                     .createdAt(notification.getCreatedAt())
                     .type(notification.getType())
                     .studyId(notification.getStudy().getId())
+                    .studyPostId(notification.getStudyPostId())
                     .studyTitle(notification.getStudy().getTitle())
                     .studyProfileImage(notification.getStudy().getProfileImage())
                     .notifierName(notification.getNotifierName()) // 알림 생성한 회원 이름

--- a/src/main/java/com/example/spot/service/studypost/StudyPostCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/studypost/StudyPostCommandServiceImpl.java
@@ -135,12 +135,13 @@ public class StudyPostCommandServiceImpl implements StudyPostCommandService {
             // 알림 생성
             for (Member studyMember : members) {
                 Notification notification = Notification.builder()
-                    .study(studyPost.getStudy())
-                    .member(studyMember)
-                    .notifierName(member.getName()) // 글을 작성한 회원 이름
-                    .type(NotifyType.ANNOUNCEMENT)
-                    .isChecked(false)
-                    .build();
+                        .study(studyPost.getStudy())
+                        .member(studyMember)
+                        .studyPostId(studyPost.getId())
+                        .notifierName(member.getName()) // 글을 작성한 회원 이름
+                        .type(NotifyType.ANNOUNCEMENT)
+                        .isChecked(false)
+                        .build();
                 notificationRepository.save(notification);
             }
         }

--- a/src/main/java/com/example/spot/web/dto/notification/NotificationResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/notification/NotificationResponseDTO.java
@@ -26,6 +26,8 @@ public class NotificationResponseDTO {
         @AllArgsConstructor
         public static class NotificationDTO{
             Long notificationId;
+            Long studyId;
+            Long studyPostId;
             String studyTitle;
             String studyProfileImage;
             String notifierName;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #413 

<br/>

## 🔎 작업 내용

1. Notification 엔티티에서 스터디 공지 글 ID를 저장할 수 있게, `studyPostId` 필드 추가 -`StudyPost → Notification`로의 탐색은 필요 없다고 생각해서 정수형 필드만 하나 뒀습니다! 
2. 응답 시 해당 알림이 발생한 스터디의 고유 식별자도 함께 응답하도록 구현
<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
