### PR TITLE
[FEAT] 스터디 히스토리 조회 API 구현

### DIFF
--- a/src/main/java/com/example/spot/domain/mapping/MemberStudy.java
+++ b/src/main/java/com/example/spot/domain/mapping/MemberStudy.java
@@ -3,12 +3,15 @@ package com.example.spot.domain.mapping;
 import com.example.spot.domain.Member;
 import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.enums.ApplicationStatus;
+import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.study.Study;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -38,6 +41,12 @@ public class MemberStudy extends BaseEntity {
     @Setter
     private String reason;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status activeStatus;
+
+    private LocalDateTime finishedAt;
+
     //== 회원 ==//
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
@@ -63,6 +72,8 @@ public class MemberStudy extends BaseEntity {
         this.study = study;
         this.status = status;
     }
-
-
+    public void disable() {
+        this.activeStatus = Status.OFF;
+        this.finishedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/spot/domain/study/Study.java
+++ b/src/main/java/com/example/spot/domain/study/Study.java
@@ -1,12 +1,10 @@
 package com.example.spot.domain.study;
 
 import com.example.spot.domain.Notification;
-import com.example.spot.domain.Quiz;
 import com.example.spot.domain.common.BaseEntity;
 import com.example.spot.domain.enums.Gender;
 import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.enums.StudyState;
-import com.example.spot.domain.enums.ThemeType;
 import com.example.spot.domain.mapping.MemberStudy;
 import com.example.spot.domain.mapping.PreferredStudy;
 import com.example.spot.domain.mapping.RegionStudy;
@@ -20,12 +18,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import lombok.*;
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
@@ -87,6 +84,8 @@ public class Study extends BaseEntity {
 
     @Column(nullable = false)
     private Long maxPeople;
+
+    private LocalDateTime finishedAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
@@ -207,6 +206,7 @@ public class Study extends BaseEntity {
         this.studyState = StudyState.COMPLETED;
         this.status = Status.OFF;
         this.performance = performance;
+        this.finishedAt = LocalDateTime.now();
     }
 
     public void updateStudyInfo(

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -42,6 +42,7 @@ public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> 
                 s.study_state = 'COMPLETED'
                 OR ms.active_status = 'OFF'
               )
+        ORDER BY ms.created_at DESC
         """,
             countQuery = """
         SELECT COUNT(*)

--- a/src/main/java/com/example/spot/repository/MemberStudyRepository.java
+++ b/src/main/java/com/example/spot/repository/MemberStudyRepository.java
@@ -4,8 +4,11 @@ import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.ApplicationStatus;
 import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.mapping.MemberStudy;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -27,6 +30,34 @@ public interface MemberStudyRepository extends JpaRepository<MemberStudy, Long> 
     Optional<MemberStudy> findByMemberIdAndStudyIdAndIsOwned(Long memberId, Long studyId, Boolean isOwned);
 
     Optional<MemberStudy> findByMemberIdAndStudyId(Long memberId, Long studyId);
+
+    @Query(
+            value = """
+        SELECT ms.*
+        FROM member_study ms
+        JOIN study s ON ms.study_id = s.id
+        WHERE ms.member_id = :memberId
+          AND ms.status = 'APPROVED'
+          AND (
+                s.study_state = 'COMPLETED'
+                OR ms.active_status = 'OFF'
+              )
+        """,
+            countQuery = """
+        SELECT COUNT(*)
+        FROM member_study ms
+        JOIN study s ON ms.study_id = s.id
+        WHERE ms.member_id = :memberId
+          AND ms.status = 'APPROVED'
+          AND (
+                s.study_state = 'COMPLETED'
+                OR ms.active_status = 'OFF'
+              )
+        """,
+            nativeQuery = true
+    )
+    Page<MemberStudy> findAllByMemberIdAndConditions(@Param("memberId") Long memberId, Pageable pageable);
+
 
     long countByStatusAndStudyId(ApplicationStatus status, Long studyId);
     long countByMemberIdAndStatusAndStudy_Status(Long memberId, ApplicationStatus applicationStatus, Status status);

--- a/src/main/java/com/example/spot/repository/querydsl/StudyRepositoryCustom.java
+++ b/src/main/java/com/example/spot/repository/querydsl/StudyRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.example.spot.repository.querydsl;
 import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.enums.StudySortBy;
+import com.example.spot.domain.enums.StudyState;
 import com.example.spot.domain.mapping.MemberStudy;
 import com.example.spot.domain.mapping.RegionStudy;
 import com.example.spot.domain.mapping.StudyTheme;
@@ -38,7 +39,7 @@ public interface StudyRepositoryCustom {
 
     List<Study> findByMemberStudiesAndStatus(List<MemberStudy> memberStudy, Pageable pageable, Status status);
     List<Study> findRecruitingStudiesByMemberStudy(List<MemberStudy> memberStudy, Pageable pageable);
-    Page<Study> findFinishedStudies(Member member, Status status, Pageable pageable);
+    Page<Study> findFinishedStudies(Member member, Pageable pageable);
 
     long countStudyByConditionsAndThemeTypesAndNotInIds(
         Map<String, Object> search, List<StudyTheme> themeTypes, StudySortBy sortBy, List<Long> studyIds);

--- a/src/main/java/com/example/spot/repository/querydsl/StudyRepositoryCustom.java
+++ b/src/main/java/com/example/spot/repository/querydsl/StudyRepositoryCustom.java
@@ -39,7 +39,7 @@ public interface StudyRepositoryCustom {
 
     List<Study> findByMemberStudiesAndStatus(List<MemberStudy> memberStudy, Pageable pageable, Status status);
     List<Study> findRecruitingStudiesByMemberStudy(List<MemberStudy> memberStudy, Pageable pageable);
-    Page<Study> findFinishedStudies(Member member, Pageable pageable);
+
 
     long countStudyByConditionsAndThemeTypesAndNotInIds(
         Map<String, Object> search, List<StudyTheme> themeTypes, StudySortBy sortBy, List<Long> studyIds);

--- a/src/main/java/com/example/spot/repository/querydsl/StudyRepositoryCustom.java
+++ b/src/main/java/com/example/spot/repository/querydsl/StudyRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.example.spot.repository.querydsl;
 
+import com.example.spot.domain.Member;
 import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.enums.StudySortBy;
 import com.example.spot.domain.mapping.MemberStudy;
@@ -9,6 +10,7 @@ import com.example.spot.domain.study.Study;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface StudyRepositoryCustom {
@@ -36,6 +38,7 @@ public interface StudyRepositoryCustom {
 
     List<Study> findByMemberStudiesAndStatus(List<MemberStudy> memberStudy, Pageable pageable, Status status);
     List<Study> findRecruitingStudiesByMemberStudy(List<MemberStudy> memberStudy, Pageable pageable);
+    Page<Study> findFinishedStudies(Member member, Status status, Pageable pageable);
 
     long countStudyByConditionsAndThemeTypesAndNotInIds(
         Map<String, Object> search, List<StudyTheme> themeTypes, StudySortBy sortBy, List<Long> studyIds);

--- a/src/main/java/com/example/spot/repository/querydsl/impl/StudyRepositoryCustomImpl.java
+++ b/src/main/java/com/example/spot/repository/querydsl/impl/StudyRepositoryCustomImpl.java
@@ -284,34 +284,6 @@ SELECT id FROM study WHERE MATCH(title) AGAINST (:keyword IN NATURAL LANGUAGE MO
     }
 
     @Override
-    public Page<Study> findFinishedStudies(Member member, Pageable pageable) {
-        List<Study> content = queryFactory
-                .selectFrom(study)
-                .join(study.memberStudies, memberStudy)
-                .where(
-                        memberStudy.member.id.eq(member.getId()),
-                        memberStudy.status.eq(ApplicationStatus.APPROVED),
-                        study.studyState.eq(StudyState.COMPLETED)
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-
-        Long count = queryFactory
-                .select(study.count())
-                .from(study)
-                .join(study.memberStudies, memberStudy)
-                .where(
-                        memberStudy.member.id.eq(member.getId()),
-                        memberStudy.status.eq(ApplicationStatus.APPROVED),
-                        study.studyState.eq(StudyState.COMPLETED)
-                )
-                .fetchOne();
-
-        return new PageImpl<>(content, pageable, count != null ? count : 0);
-    }
-
-    @Override
     public long countStudyByConditionsAndThemeTypesAndNotInIds(Map<String, Object> search,
         List<StudyTheme> themeTypes, StudySortBy sortBy, List<Long> studyIds) {
         BooleanBuilder builder = getBooleanBuilderByThemeTypes(search, study, themeTypes);

--- a/src/main/java/com/example/spot/repository/querydsl/impl/StudyRepositoryCustomImpl.java
+++ b/src/main/java/com/example/spot/repository/querydsl/impl/StudyRepositoryCustomImpl.java
@@ -284,14 +284,14 @@ SELECT id FROM study WHERE MATCH(title) AGAINST (:keyword IN NATURAL LANGUAGE MO
     }
 
     @Override
-    public Page<Study> findFinishedStudies(Member member, Status status, Pageable pageable) {
+    public Page<Study> findFinishedStudies(Member member, Pageable pageable) {
         List<Study> content = queryFactory
                 .selectFrom(study)
                 .join(study.memberStudies, memberStudy)
                 .where(
                         memberStudy.member.id.eq(member.getId()),
                         memberStudy.status.eq(ApplicationStatus.APPROVED),
-                        study.status.eq(Status.OFF)
+                        study.studyState.eq(StudyState.COMPLETED)
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -304,7 +304,7 @@ SELECT id FROM study WHERE MATCH(title) AGAINST (:keyword IN NATURAL LANGUAGE MO
                 .where(
                         memberStudy.member.id.eq(member.getId()),
                         memberStudy.status.eq(ApplicationStatus.APPROVED),
-                        study.status.eq(Status.OFF)
+                        study.studyState.eq(StudyState.COMPLETED)
                 )
                 .fetchOne();
 

--- a/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/memberstudy/MemberStudyCommandServiceImpl.java
@@ -96,7 +96,8 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
             throw new StudyHandler(ErrorStatus._STUDY_OWNER_CANNOT_WITHDRAW);
         }
 
-        memberStudyRepository.delete(memberStudy);
+        memberStudy.disable();
+        memberStudyRepository.save(memberStudy);
 
         return StudyWithdrawalResponseDTO.WithdrawalDTO.toDTO(member, study);
     }
@@ -117,7 +118,11 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
         MemberStudy newHostStudy = memberStudyRepository.findByMemberIdAndStudyIdAndStatus(requestDTO.getNewHostId(), studyId, ApplicationStatus.APPROVED)
                 .orElseThrow(() -> new StudyHandler(ErrorStatus._STUDY_MEMBER_NOT_EXIST));
 
-        memberStudyRepository.delete(memberStudy);
+
+        // memberStudyRepository.delete(memberStudy);
+
+        memberStudy.disable();
+        memberStudy.setIsOwned(false);
 
         newHostStudy.setIsOwned(true);
         newHostStudy.setReason(requestDTO.getReason());
@@ -154,6 +159,7 @@ public class MemberStudyCommandServiceImpl implements MemberStudyCommandService 
             throw new StudyHandler(ErrorStatus._STUDY_ALREADY_TERMINATED);
         }
 
+        memberStudy.disable();
         study.terminateStudy(performance);
         studyRepository.save(study);
 

--- a/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyCommandServiceImpl.java
@@ -100,6 +100,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
                 .member(member)
                 .study(study)
                 .status(ApplicationStatus.APPLIED)
+                .activeStatus(Status.ON)
                 .build();
 
         member.addMemberStudy(memberStudy);
@@ -239,6 +240,7 @@ public class StudyCommandServiceImpl implements StudyCommandService {
                 .member(member)
                 .study(study)
                 .status(ApplicationStatus.APPROVED)
+                .activeStatus(Status.ON)
                 .build();
 
         member.addMemberStudy(memberStudy);

--- a/src/main/java/com/example/spot/service/study/StudyQueryService.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryService.java
@@ -7,10 +7,8 @@ import com.example.spot.web.dto.search.SearchRequestStudyWithThemeDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.HotKeywordDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.StudyPreviewDTO;
+import com.example.spot.web.dto.search.StudyHistoryResponseDTO;
 import com.example.spot.web.dto.study.response.StudyInfoResponseDTO;
-import com.example.spot.web.dto.study.response.StudyMemberResponseDTO;
-import com.example.spot.web.dto.study.response.StudyPostResponseDTO;
-import com.example.spot.web.dto.study.response.StudyScheduleResponseDTO;
 import org.springframework.data.domain.Pageable;
 
 public interface StudyQueryService {
@@ -71,4 +69,5 @@ public interface StudyQueryService {
     // 내가 모집중인 스터디 조회
     StudyPreviewDTO findMyRecruitingStudies(Pageable pageable, Long memberId);
 
+    StudyHistoryResponseDTO getFinishedStudies(Pageable pageable, Long currentUserId);
 }

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -38,6 +38,7 @@ import com.example.spot.web.dto.search.SearchResponseDTO.HotKeywordDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.SearchStudyDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.StudyPreviewDTO;
+import com.example.spot.web.dto.search.StudyHistoryResponseDTO;
 import com.example.spot.web.dto.study.response.StudyInfoResponseDTO;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -831,6 +832,14 @@ public class StudyQueryServiceImpl implements StudyQueryService {
         long totalElements = studyRepository.countByMemberStudiesAndStatusAndIsOwned(memberStudies, Status.ON, true);
 
         return getDTOs(studies, pageable, totalElements, memberId);
+    }
+
+    @Override
+    public StudyHistoryResponseDTO getFinishedStudies(Pageable pageable, Long currentUserId) {
+        Member member = memberRepository.findById(currentUserId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
+        Page<Study> finishedStudies = studyRepository.findFinishedStudies(member, Status.OFF, pageable);
+        return StudyHistoryResponseDTO.of(finishedStudies);
     }
 
     /**

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.spot.domain.enums.Gender;
 import com.example.spot.domain.enums.Status;
 import com.example.spot.domain.enums.StudyLikeStatus;
 import com.example.spot.domain.enums.StudySortBy;
+import com.example.spot.domain.enums.StudyState;
 import com.example.spot.domain.enums.ThemeType;
 import com.example.spot.domain.mapping.MemberStudy;
 import com.example.spot.domain.mapping.MemberTheme;
@@ -838,7 +839,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
     public StudyHistoryResponseDTO getFinishedStudies(Pageable pageable, Long currentUserId) {
         Member member = memberRepository.findById(currentUserId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
-        Page<Study> finishedStudies = studyRepository.findFinishedStudies(member, Status.OFF, pageable);
+        Page<Study> finishedStudies = studyRepository.findFinishedStudies(member, pageable);
         return StudyHistoryResponseDTO.of(finishedStudies);
     }
 

--- a/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
+++ b/src/main/java/com/example/spot/service/study/StudyQueryServiceImpl.java
@@ -839,7 +839,7 @@ public class StudyQueryServiceImpl implements StudyQueryService {
     public StudyHistoryResponseDTO getFinishedStudies(Pageable pageable, Long currentUserId) {
         Member member = memberRepository.findById(currentUserId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus._MEMBER_NOT_FOUND));
-        Page<Study> finishedStudies = studyRepository.findFinishedStudies(member, pageable);
+        Page<MemberStudy> finishedStudies = memberStudyRepository.findAllByMemberIdAndConditions(currentUserId, pageable);
         return StudyHistoryResponseDTO.of(finishedStudies);
     }
 

--- a/src/main/java/com/example/spot/web/controller/SearchController.java
+++ b/src/main/java/com/example/spot/web/controller/SearchController.java
@@ -12,6 +12,7 @@ import com.example.spot.web.dto.search.SearchRequestStudyWithThemeDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.HotKeywordDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.MyPageDTO;
 import com.example.spot.web.dto.search.SearchResponseDTO.StudyPreviewDTO;
+import com.example.spot.web.dto.search.StudyHistoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -424,6 +425,24 @@ public class SearchController {
             PageRequest.of(page, size), SecurityUtils.getCurrentUserId());
         return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, studies);
     }
+
+    /* ----------------------------- 신청한 스터디 목록 조회  ------------------------------------- */
+    @Tag(name = "마이 페이지")
+    @Operation(summary = "[마이 페이지] 사용자님의 노력들 조회", description = """ 
+        
+        ## [마이페이지] 
+        호스트가 종료한 스터디, 그리고 스터디원(호스트포함) 본인이 탈퇴한 스터디의 정보와 스터디 한줄 평가를 조회합니다.
+        """)
+    @GetMapping("/search/studies/finished-studies")
+    public ApiResponse<?> getFinishedStudies(
+        @RequestParam @Min(0) Integer page,
+        @RequestParam @Min(1) Integer size
+    ) {
+        StudyHistoryResponseDTO responseDTO = studyQueryService.getFinishedStudies(PageRequest.of(page, size),
+                SecurityUtils.getCurrentUserId());
+        return ApiResponse.onSuccess(SuccessStatus._STUDY_FOUND, responseDTO);
+    }
+
 
 
 

--- a/src/main/java/com/example/spot/web/dto/search/StudyHistoryResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/StudyHistoryResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.spot.web.dto.search;
 
+import com.example.spot.domain.mapping.MemberStudy;
 import com.example.spot.domain.study.Study;
 import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
@@ -7,13 +8,13 @@ import org.springframework.data.domain.Page;
 public record StudyHistoryResponseDTO (
         Page<StudyHistoryDTO> studyHistories
 ) {
-    public static StudyHistoryResponseDTO of(Page<Study> studies) {
-        return new StudyHistoryResponseDTO(studies.map(study -> new StudyHistoryDTO(
-                study.getId(),
-                study.getTitle(),
-                study.getPerformance(),
-                study.getCreatedAt(),
-                study.getFinishedAt()
+    public static StudyHistoryResponseDTO of(Page<MemberStudy> studies) {
+        return new StudyHistoryResponseDTO(studies.map(memberStudy -> new StudyHistoryDTO(
+                memberStudy.getStudy().getId(),
+                memberStudy.getStudy().getTitle(),
+                memberStudy.getStudy().getPerformance(),
+                memberStudy.getCreatedAt(),
+                memberStudy.getFinishedAt()
         )));
     }
 

--- a/src/main/java/com/example/spot/web/dto/search/StudyHistoryResponseDTO.java
+++ b/src/main/java/com/example/spot/web/dto/search/StudyHistoryResponseDTO.java
@@ -1,0 +1,28 @@
+package com.example.spot.web.dto.search;
+
+import com.example.spot.domain.study.Study;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+
+public record StudyHistoryResponseDTO (
+        Page<StudyHistoryDTO> studyHistories
+) {
+    public static StudyHistoryResponseDTO of(Page<Study> studies) {
+        return new StudyHistoryResponseDTO(studies.map(study -> new StudyHistoryDTO(
+                study.getId(),
+                study.getTitle(),
+                study.getPerformance(),
+                study.getCreatedAt(),
+                study.getFinishedAt()
+        )));
+    }
+
+    private record StudyHistoryDTO (
+            Long studyId,
+            String title,
+            String performance,
+            LocalDateTime createdAt,
+            LocalDateTime finishedAt
+    ) {
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #425 

<br/>

## 🔎 작업 내용

- `MemberStudy`에 종료 시간, 상태 컬럼 추가
- 스터디 히스토리 조회 API 구현

<br/>

## 📷 스크린샷 (선택)
> 작업한 결과물에 대한 간단한 스크린샷을 올려주세요.
> 
<br/>

## 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
